### PR TITLE
Running thru master parse not required

### DIFF
--- a/src/parse.py
+++ b/src/parse.py
@@ -14,6 +14,39 @@ clear_dir("output")  # Clear the data directory before parsing
 
 parse_localizations()
 print()
-#parse_modules() #module relies on english localization being added to each key just as a helpful Ctrl+F reference
-#parse_pilots()  # Pilot parser relies on module data being parsed first
+parse_modules() #module relies on english localization being added to each key just as a helpful Ctrl+F reference
+parse_pilots()  # Pilot parser relies on module data being parsed first
 parse_progression_table()
+
+ProgressionTable.to_file()
+Currency.to_file()
+ContentUnlock.to_file()
+Decal.to_file()
+CustomizationType.to_file()
+CustomizationRarity.to_file()
+Rarity.to_file()
+GroupReward.to_file()
+Material.to_file()
+Weathering.to_file()
+Skin.to_file()
+Image.to_file()
+
+Module.to_file()
+ModuleRarity.to_file()
+CharacterModule.to_file()
+Faction.to_file()
+ModuleClass.to_file()
+CharacterClass.to_file()
+ModuleTag.to_file()
+ModuleType.to_file()
+ModuleCategory.to_file()
+ModuleSocketType.to_file()
+ModuleStat.to_file()
+ModuleStatsTable.to_file()
+
+Pilot.to_file()
+PilotType.to_file()
+PilotClass.to_file()
+PilotPersonality.to_file()
+PilotTalentType.to_file()
+PilotTalent.to_file()

--- a/src/parsers/localization_table.py
+++ b/src/parsers/localization_table.py
@@ -39,9 +39,12 @@ def parse_localization(data: dict):
     
     if localization_key is not None and localization_table_namespace is not None:
         localization_obj_english = Localization.get_from_id("en")
-        localization_english = localization_obj_english._localize(localization_table_namespace, localization_key)
-        if localization_english is None:
-            localization_english = localization_key
+        if localization_obj_english is None:
+            localization_english = None
+        else:
+            localization_english = localization_obj_english._localize(localization_table_namespace, localization_key)
+            if localization_english is None:
+                localization_english = localization_key
 
         return {
             "Key": localization_key,

--- a/src/parsers/module.py
+++ b/src/parsers/module.py
@@ -290,7 +290,7 @@ class Module(Object):
                 self.levels["scrap_rewards"]["variables"].append(parsed_scrap_rewards)
 
 
-def parse_modules():
+def parse_modules(to_file=False):
     modules_source_path = os.path.join(PARAMS.export_path, r"WRFrontiers\Content\Sparrow\Mechanics\Meta\Entities\Modules")
     for file in os.listdir(modules_source_path):
         if file.endswith(".json"):
@@ -300,21 +300,22 @@ def parse_modules():
             module_data = get_json_data(full_path)
             module = Module(module_id, module_data)
 
-    Module.to_file()
-    ModuleRarity.to_file()
-    Rarity.to_file()
-    CharacterModule.to_file()
-    Faction.to_file()
-    ModuleClass.to_file()
-    CharacterClass.to_file()
-    ModuleTag.to_file()
-    ModuleType.to_file()
-    ModuleCategory.to_file()
-    ModuleSocketType.to_file()
-    ModuleStat.to_file()
-    ModuleStatsTable.to_file()
-    Currency.to_file()
-    Image.to_file()
+    if to_file: # Condition prevents needlessly saving the same data multiple times, as it will also be saved if ran thru parse.py
+        Module.to_file()
+        ModuleRarity.to_file()
+        Rarity.to_file()
+        CharacterModule.to_file()
+        Faction.to_file()
+        ModuleClass.to_file()
+        CharacterClass.to_file()
+        ModuleTag.to_file()
+        ModuleType.to_file()
+        ModuleCategory.to_file()
+        ModuleSocketType.to_file()
+        ModuleStat.to_file()
+        ModuleStatsTable.to_file()
+        Currency.to_file()
+        Image.to_file()
 
 if __name__ == "__main__":
-    parse_modules()
+    parse_modules(to_file=True)

--- a/src/parsers/object.py
+++ b/src/parsers/object.py
@@ -6,7 +6,6 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from utils import PARAMS, path_to_id, asset_path_to_file_path, get_json_data, log, to_snake_case
 
 import json
-import re
 
 class Object: #generic object that all classes extend
     objects = dict()  # Dictionary to hold all object instances

--- a/src/parsers/pilot.py
+++ b/src/parsers/pilot.py
@@ -110,34 +110,34 @@ def parse_pilot_wrapper(dir, file_name):
     Pilot.objects[pilot_id] = pilot
     return pilot
 
-def parse_pilots():
+def parse_pilots(to_file=False):
     pilots_source_path = os.path.join(PARAMS.export_path, r"WRFrontiers\Content\Sparrow\Pilots\PilotsDataAssets")
     
     # Hero pilots are in this dir directly
     for file in os.listdir(pilots_source_path):
         if file == 'DA_Pilot_FiringRange.json':
             continue # guessing this is used as a placeholder when in the firing range, it has dummy values
-        parse_pilot_wrapper(pilots_source_path, file)
+        pilot = parse_pilot_wrapper(pilots_source_path, file)
 
     # Common pilots are in a subdir:
     common_pilots_path = os.path.join(pilots_source_path, "CommonPilots")
     for file in os.listdir(common_pilots_path):
-        parse_pilot_wrapper(common_pilots_path, file)
+        pilot = parse_pilot_wrapper(common_pilots_path, file)
 
-
-    Pilot.to_file()
-    Faction.to_file()
-    Currency.to_file()
-    PilotType.to_file()
-    Rarity.to_file()
-    GroupReward.to_file()
-    PilotClass.to_file()
-    PilotPersonality.to_file()
-    PilotTalentType.to_file()
-    PilotTalent.to_file()
-    ModuleStat.to_file()
-    ModuleTag.to_file()
-    Image.to_file()
+    if to_file: # Condition prevents needlessly saving the same data multiple times, as it will also be saved if ran thru parse.py
+        Pilot.to_file()
+        Faction.to_file()
+        Currency.to_file()
+        PilotType.to_file()
+        Rarity.to_file()
+        GroupReward.to_file()
+        PilotClass.to_file()
+        PilotPersonality.to_file()
+        PilotTalentType.to_file()
+        PilotTalent.to_file()
+        ModuleStat.to_file()
+        ModuleTag.to_file()
+        Image.to_file()
 
 if __name__ == "__main__":
-    parse_pilots()
+    parse_pilots(to_file=True)

--- a/src/parsers/progression_table.py
+++ b/src/parsers/progression_table.py
@@ -99,25 +99,25 @@ class ProgressionTable(Object):
         if data != 0:
             raise ValueError("Data structure change, ProgressionTable level attribute is no longer always 0.")
 
-def parse_progression_table():
+def parse_progression_table(to_file=False):
     progression_table_path = r"WRFrontiers/Content/Sparrow/Mechanics/DA_ProgressionTable.json"
 
     # Hero pilots are in this dir directly
     progression_table = ProgressionTable.get_from_asset_path(progression_table_path)
 
-    ProgressionTable.to_file()
-    Currency.to_file()
-    ContentUnlock.to_file()
-    Decal.to_file()
-    CustomizationType.to_file()
-    CustomizationRarity.to_file()
-    Rarity.to_file()
-    GroupReward.to_file()
-    Material.to_file()
-    Weathering.to_file()
-    Skin.to_file()
-
-    Image.to_file()
+    if to_file: # Condition prevents needlessly saving the same data multiple times, as it will also be saved if ran thru parse.py
+        ProgressionTable.to_file()
+        Currency.to_file()
+        ContentUnlock.to_file()
+        Decal.to_file()
+        CustomizationType.to_file()
+        CustomizationRarity.to_file()
+        Rarity.to_file()
+        GroupReward.to_file()
+        Material.to_file()
+        Weathering.to_file()
+        Skin.to_file()
+        Image.to_file()
 
 if __name__ == "__main__":
-    parse_progression_table()
+    parse_progression_table(to_file=True)

--- a/todo.txt
+++ b/todo.txt
@@ -5,4 +5,3 @@
 # parse weapon falloff curves
 # check if burst interval can be parsed, like time between shots in bayonet's 3 bullet burst.
 # check if theres any stat that determines how frequently weapons like zeus can fire when they have infinite ammo
-# verify that to_file()ing every parser in parse.py does not impact outpu


### PR DESCRIPTION
Root parsers (pilot, module, progression table thus far) can now be ran directly, as opposed to only through parse.py. This is done by allowing the english translation to be null as opposed to erroring due to localization objects not being parsed.