### PR TITLE
UpgradeCost class and other level attributes cleaned up

### DIFF
--- a/src/analysis.py
+++ b/src/analysis.py
@@ -7,12 +7,11 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import log, PARAMS, sort_dict
 
-
 class Analysis:
-
-    def __init__(self, module_class, module_stat_class):
+    def __init__(self, module_class, module_stat_class, upgrade_cost_class):
         self.module_class = module_class
         self.module_stat_class = module_stat_class
+        self.upgrade_cost_class = upgrade_cost_class
         self._analyze_level_differences()
 
     def _extract_base_and_max(self, module):
@@ -50,12 +49,13 @@ class Analysis:
         if module_scalars is None:
             return None
         for level_index, level_data in enumerate(module_scalars['variables']):
-            upgrade_cost = level_data.get('UpgradeCurrency')
-            if not upgrade_cost:
-                log(f"Warning: No upgrade cost found for module {getattr(module, 'id', None)} at level {level_index+1}")
+            upgrade_cost_id = level_data.get('upgrade_currency_id')
+            if upgrade_cost_id is None:
+                log(f"Warning: No upgrade cost ID found for module {getattr(module, 'id', None)} at level {level_index+1}")
                 continue
-            currency_id = upgrade_cost['currency_id']
-            currency_amount = upgrade_cost['amount']
+            upgrade_cost = self.upgrade_cost_class.objects[upgrade_cost_id]
+            currency_id = upgrade_cost.currency_id
+            currency_amount = upgrade_cost.amount
             module_upgrade_costs[currency_id] = module_upgrade_costs.get(currency_id, 0) + currency_amount
             total_upgrade_costs[currency_id] = total_upgrade_costs.get(currency_id, 0) + currency_amount
         return module_upgrade_costs
@@ -136,7 +136,7 @@ class Analysis:
             level_base, level_max = self._extract_base_and_max(module)
             diff = {}
             for key in level_base.keys():
-                if key in superficial_keys or key in {'ScrapRewards', 'UpgradeCurrency'}:
+                if key in superficial_keys or key in ['ScrapRewards', 'upgrade_currency_id']:
                     continue
                 base_value = level_base[key]
                 max_value = level_max[key]
@@ -185,6 +185,6 @@ class Analysis:
         with open(file_path, 'w', encoding='utf-8') as f:
             f.write(self.to_json())
 
-def analyze(module_class, module_stat_class):
-    analysis = Analysis(module_class, module_stat_class)
+def analyze(module_class, module_stat_class, upgrade_cost_class):
+    analysis = Analysis(module_class, module_stat_class, upgrade_cost_class)
     analysis.to_file()

--- a/src/parse.py
+++ b/src/parse.py
@@ -56,7 +56,7 @@ parse_progression_table()
 parse_game_modes()
 parse_bot_presets()
 parse_powerups()
-analyze(Module, ModuleStat)
+analyze(Module, ModuleStat, UpgradeCost)
 
 
 ProgressionTable.to_file()
@@ -84,6 +84,7 @@ ModuleCategory.to_file()
 ModuleSocketType.to_file()
 ModuleStat.to_file()
 ModuleStatsTable.to_file()
+UpgradeCost.to_file()
 
 Pilot.to_file()
 PilotType.to_file()

--- a/src/parsers/module.py
+++ b/src/parsers/module.py
@@ -164,11 +164,12 @@ class Module(Object):
 
             parsed_level = dict()
 
+            # Parse upgrade and scrap currencies
             if "UpgradeCurrency" in level and "UpgradeCost" in level:
                 upgrade_currency = level["UpgradeCurrency"]
                 upgrade_cost = level["UpgradeCost"]
                 level_num = level["Level"]
-                if upgrade_currency is not None:
+                if upgrade_currency is not None and upgrade_currency != "None": #it may be None if its say a torso ability module, as the ability is not what costs currency to upgrade, rather the module its attached to (torso) will have the cost
                     upgrade_cost = UpgradeCost(self.id, level_num, upgrade_currency, upgrade_cost)
                     parsed_level["upgrade_currency_id"] = upgrade_cost.id
 
@@ -181,22 +182,65 @@ class Module(Object):
                 if scrap_reward_currency_key in level and scrap_reward_amount_key in level:
                     scrap_reward_currency = level[scrap_reward_currency_key]
                     scrap_reward_amount = level[scrap_reward_amount_key]
-                    if scrap_reward_currency is not None:
+                    if scrap_reward_currency is not None and scrap_reward_currency != "None":
                         parsed_level['ScrapRewards'].append({
                             "currency_id": scrap_reward_currency,
                             "amount": scrap_reward_amount
                         })
                 
-
             parsed_level["ScrapRewards"] = []
             _p_scrap_reward_amount("First")
             _p_scrap_reward_amount("Second")
 
+
+            # Parse module class and tags
+            def _p_module_class_tag_fac(class_or_tag, one_or_two):
+                """
+                class_or_tag: "Class" or "Tag" or "Faction"
+                one_or_two: "1" or "2" or "0" (0 indicates no underscore will be used too)
+                """
+                underscore_and_number = f"_{one_or_two}" if one_or_two in ["1", "2"] else ""
+                module_classtagfac_key = f"Module{class_or_tag}{underscore_and_number}"
+                if module_classtagfac_key in level:
+                    module_classtagfac_id = level[module_classtagfac_key]
+                else:
+                    log(f"Warning: Module {self.id} level {level['Level']} is missing {module_classtagfac_key}", tabs=2)
+
+                if module_classtagfac_id == 'None':
+                    return None
+
+                return module_classtagfac_id
+            
+            def _add_to_parsed_level_if_not_none(key, value):
+                if value is not None:
+                    parsed_level[key] = value
+
+            _add_to_parsed_level_if_not_none("module_class_id_1", _p_module_class_tag_fac("Class", "1"))
+            _add_to_parsed_level_if_not_none("module_class_id_2", _p_module_class_tag_fac("Class", "2"))
+            _add_to_parsed_level_if_not_none("module_tag_id_1", _p_module_class_tag_fac("Tag", "1"))
+            _add_to_parsed_level_if_not_none("module_tag_id_2", _p_module_class_tag_fac("Tag", "2"))
+            _add_to_parsed_level_if_not_none("module_faction_id", _p_module_class_tag_fac("Faction", "0"))
+
+
+            # Parse load/energy capacity
+            def add_to_parsed_level_if_not_0(key, value):
+                if value is not None and value != 0:
+                    parsed_level[key] = value
+            add_to_parsed_level_if_not_0("LoadCapacity", level.get("LoadCapacity"))
+            add_to_parsed_level_if_not_0("EnergyCapacity", level.get("EnergyCapacity"))
+
+
             # Include all other key data pairs in the level
             for key, value in level.items():
-                if key in ["UpgradeCurrency", "UpgradeCost", "FirstScrapRewardAmount", "FirstScrapRewardCurrency", "SecondScrapRewardAmount", "SecondScrapRewardCurrency"]: #already parsed above
+                if key in ["Level", "UpgradeCurrency", "UpgradeCost", 
+                           "FirstScrapRewardAmount", "FirstScrapRewardCurrency", "SecondScrapRewardAmount", "SecondScrapRewardCurrency", 
+                           "ModuleClass_1", "ModuleClass_2", "ModuleTag_1", "ModuleTag_2", "ModuleFaction",
+                           "LoadCapacity", "EnergyCapacity"
+                           ]: #already parsed above
                     pass
-                elif key in ['Health', 'Level', 'Def', 'Atk', 'Mob', 'AbilityPower', 'Mobility', 'FirePower']: #flavor stats that are technically meaningless. Also not displayed anywhere as of 8-26 hangar UI changes.
+                elif key in ['Health', 'Def', 'Atk', 'Mob', 'AbilityPower', 'Mobility', 'FirePower']: #flavor stats that are technically meaningless. Also not displayed anywhere as of 8-26 hangar UI changes.
+                    pass
+                elif key in ['bIsPerk']: #no clue what this means; its bool but can vary per level, i.e. typhon chassis lvl5 true, lvl6 false
                     pass
                 else:
                     parsed_level[key] = value

--- a/src/parsers/module.py
+++ b/src/parsers/module.py
@@ -20,7 +20,8 @@ from parsers.module_category import ModuleCategory
 from parsers.module_socket_type import ModuleSocketType
 from parsers.module_stat import ModuleStat
 from parsers.module_stats_table import ModuleStatsTable
-from parsers.currency import Currency, parse_currency
+from parsers.currency import Currency
+from parsers.upgrade_cost import UpgradeCost
 from parsers.image import parse_image_asset_path, Image
 
 class Module(Object):
@@ -166,11 +167,10 @@ class Module(Object):
             if "UpgradeCurrency" in level and "UpgradeCost" in level:
                 upgrade_currency = level["UpgradeCurrency"]
                 upgrade_cost = level["UpgradeCost"]
+                level_num = level["Level"]
                 if upgrade_currency is not None:
-                    parsed_level["UpgradeCurrency"] = {
-                        "currency_id": upgrade_currency,
-                        "amount": upgrade_cost
-                    }
+                    upgrade_cost = UpgradeCost(self.id, level_num, upgrade_currency, upgrade_cost)
+                    parsed_level["upgrade_currency_id"] = upgrade_cost.id
 
             def _p_scrap_reward_amount(first_or_second):
                 """
@@ -299,6 +299,7 @@ def parse_modules(to_file=False):
         ModuleStatsTable.to_file()
         Currency.to_file()
         Ability.to_file()
+        UpgradeCost.to_file()
         Image.to_file()
 
 if __name__ == "__main__":

--- a/src/parsers/module.py
+++ b/src/parsers/module.py
@@ -173,7 +173,7 @@ class Module(Object):
                     upgrade_cost = UpgradeCost(self.id, level_num, upgrade_currency, upgrade_cost)
                     parsed_level["upgrade_currency_id"] = upgrade_cost.id
 
-            def _p_scrap_reward_amount(first_or_second):
+            def p_scrap_reward_amount(first_or_second):
                 """
                 first_or_second: "First" or "Second"
                 """
@@ -189,12 +189,12 @@ class Module(Object):
                         })
                 
             parsed_level["ScrapRewards"] = []
-            _p_scrap_reward_amount("First")
-            _p_scrap_reward_amount("Second")
+            p_scrap_reward_amount("First")
+            p_scrap_reward_amount("Second")
 
 
             # Parse module class and tags
-            def _p_module_class_tag_fac(class_or_tag, one_or_two):
+            def p_module_class_tag_fac(class_or_tag, one_or_two):
                 """
                 class_or_tag: "Class" or "Tag" or "Faction"
                 one_or_two: "1" or "2" or "0" (0 indicates no underscore will be used too)
@@ -211,15 +211,15 @@ class Module(Object):
 
                 return module_classtagfac_id
             
-            def _add_to_parsed_level_if_not_none(key, value):
+            def add_to_parsed_level_if_not_none(key, value):
                 if value is not None:
                     parsed_level[key] = value
 
-            _add_to_parsed_level_if_not_none("module_class_id_1", _p_module_class_tag_fac("Class", "1"))
-            _add_to_parsed_level_if_not_none("module_class_id_2", _p_module_class_tag_fac("Class", "2"))
-            _add_to_parsed_level_if_not_none("module_tag_id_1", _p_module_class_tag_fac("Tag", "1"))
-            _add_to_parsed_level_if_not_none("module_tag_id_2", _p_module_class_tag_fac("Tag", "2"))
-            _add_to_parsed_level_if_not_none("module_faction_id", _p_module_class_tag_fac("Faction", "0"))
+            add_to_parsed_level_if_not_none("module_class_id_1", p_module_class_tag_fac("Class", "1"))
+            add_to_parsed_level_if_not_none("module_class_id_2", p_module_class_tag_fac("Class", "2"))
+            add_to_parsed_level_if_not_none("module_tag_id_1", p_module_class_tag_fac("Tag", "1"))
+            add_to_parsed_level_if_not_none("module_tag_id_2", p_module_class_tag_fac("Tag", "2"))
+            add_to_parsed_level_if_not_none("module_faction_id", p_module_class_tag_fac("Faction", "0"))
 
 
             # Parse load/energy capacity

--- a/src/parsers/upgrade_cost.py
+++ b/src/parsers/upgrade_cost.py
@@ -1,0 +1,24 @@
+# Add parent dirs to sys path
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from parsers.object import Object
+
+class UpgradeCost(Object):
+    objects = dict()  # Dictionary to hold all UpgradeCost instances
+
+    def __init__(self, module_id, level_num, currency_id, amount):
+        id = f"{module_id}_level{level_num}_cost"
+        super().__init__(id, {
+            "module_id": module_id,
+            "level_num": level_num,
+            "currency_id": currency_id,
+            "amount": amount
+        })
+        
+    def _parse(self):
+        self.module_id = self.source_data.get("module_id")
+        self.level_num = self.source_data.get("level_num")
+        self.currency_id = self.source_data.get("currency_id")
+        self.amount = self.source_data.get("amount")

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,3 @@
 # everything in ctrl shift f "pass"
 dps calcs
 # research what links primary/secondary stat to the modifier other than by name. Suppressor's Efficiency was not applying on the 08-26 update
-# create class for storing intel cost for an item, create an id for it, and store in separate file for diff-readability sake of Module.json


### PR DESCRIPTION
1. UpgradeCost class created. Module levels now reference an instance per moduleid-levelnum, mostly for diff reading sake
2. Level attributes ModuleClass, ModuleTag, ModuleFaction now use the same id formatting instead, like `module_class_id_1`. They are not in an array simply because they aren't stored in an array by the game yet, so no need to support this. 
3. UpgradeCost, Class, Tag, Faction, EnergyCapacity, and WeightCapacity no longer used when their values are irrelevant (0 or "None")