### PR TITLE
Split process key to parser function

### DIFF
--- a/src/parsers/ability.py
+++ b/src/parsers/ability.py
@@ -3,8 +3,8 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from parsers.object import Object, ParseTarget, ParseAction
-from utils import asset_path_to_data, log, parse_colon_colon, parse_editor_curve_data, merge_dicts, remove_blank_values
+from parsers.object import Object
+from utils import ParseTarget, ParseAction, asset_path_to_data, log, parse_colon_colon, parse_editor_curve_data, merge_dicts, remove_blank_values
 from parsers.image import parse_image_asset_path
 from parsers.localization_table import parse_localization
 from parsers.module_stat import ModuleStat

--- a/src/parsers/ability.py
+++ b/src/parsers/ability.py
@@ -4,7 +4,7 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from parsers.object import Object
-from utils import ParseTarget, ParseAction, asset_path_to_data, log, parse_colon_colon, parse_editor_curve_data, merge_dicts, remove_blank_values
+from utils import ParseTarget, ParseAction, process_key_to_parser_function, asset_path_to_data, log, parse_colon_colon, parse_editor_curve_data, merge_dicts, remove_blank_values
 from parsers.image import parse_image_asset_path
 from parsers.localization_table import parse_localization
 from parsers.module_stat import ModuleStat
@@ -625,7 +625,7 @@ def p_expansion_template(data: dict):
         "InitialRadius": "value",
         "FinishRadius": "value",
     }
-    return Ability._process_key_to_parser_function(Ability(), key_to_parser_function, props, log_descriptor="ExpansionTemplate", set_attrs=False, tabs=2, default_configuration={
+    return process_key_to_parser_function(key_to_parser_function, props, log_descriptor="ExpansionTemplate", set_attrs=False, tabs=2, default_configuration={
         'target': ParseTarget.MATCH_KEY
     })
 
@@ -669,7 +669,7 @@ def p_movement_component(data: dict):
         "bCruiseAvoidObstacles": "value",
         "bEnableCruiseMode": "value",
     }
-    return Ability._process_key_to_parser_function(Ability(), key_to_parser_function, data["Properties"], log_descriptor="MovementComponent", set_attrs=False, tabs=2, default_configuration={
+    return process_key_to_parser_function(key_to_parser_function, data["Properties"], log_descriptor="MovementComponent", set_attrs=False, tabs=2, default_configuration={
         'target': ParseTarget.MATCH_KEY
     })
 
@@ -690,8 +690,7 @@ def p_damage_applier(data: dict):
         "DamageMeshFXClass": None,
     }
 
-    parsed_data = Ability._process_key_to_parser_function(
-            Ability(), #TODO this is awful bandaid lol
+    parsed_data = process_key_to_parser_function(
             key_to_parser_function, data, log_descriptor="ActorClass", tabs=6, set_attrs=False, default_configuration={
                 'target': ParseTarget.MATCH_KEY
             }
@@ -735,7 +734,7 @@ def p_collision_component(data):
         "bHiddenInGame": None,
     }
 
-    return Ability._process_key_to_parser_function(Ability(), key_to_parser_function, props, log_descriptor="CollisionComponent", set_attrs=False, tabs=2, default_configuration={
+    return process_key_to_parser_function(key_to_parser_function, props, log_descriptor="CollisionComponent", set_attrs=False, tabs=2, default_configuration={
         'target': ParseTarget.MATCH_KEY
     })
 
@@ -775,8 +774,7 @@ def p_buff_area_component(data: dict):
         "Buffs": p_buffs,
     }
 
-    return Ability._process_key_to_parser_function(
-        Ability(),
+    return process_key_to_parser_function(
         key_to_parser_function,
         props,
         log_descriptor="BuffAreaComponent",

--- a/src/parsers/ability.py
+++ b/src/parsers/ability.py
@@ -22,6 +22,10 @@ class Ability(Object):
         for key, value in overlayed_data.items():
             setattr(self, key, value)
 
+        # Locate WeaponInfos under the misc attribute and move it to the weapon_id attribute
+        if hasattr(self, 'misc') and 'spawn_actor_action' in self.misc and 'ActorClass' in self.misc['spawn_actor_action'] and 'WeaponInfos' in self.misc['spawn_actor_action']['ActorClass']:
+            self.weapon_id = self.misc['spawn_actor_action']['ActorClass'].pop('WeaponInfos')
+
     def _parse_from_data(self, source_data: dict):
         props = source_data.get("Properties")
         if not props:
@@ -154,8 +158,8 @@ class Ability(Object):
             "TargetingMarkerClass": None,
             "AssistanceRadius": None,
             "RetributionAnimTime": None,
-            "WeaponInfos": {"parser": self._p_weapon_infos, "action": ParseAction.ATTRIBUTE, "target": "weapon"}, # ares retribution and volta tesla coil
-            "ActivateWeaponsAction": {"parser": self._p_activate_weapons_action, "action": ParseAction.ATTRIBUTE, "target": "weapon"},
+            "WeaponInfos": {"parser": self._p_weapon_infos, "action": ParseAction.ATTRIBUTE, "target": "weapon_id"}, # ares retribution and volta tesla coil
+            "ActivateWeaponsAction": {"parser": self._p_activate_weapons_action, "action": ParseAction.ATTRIBUTE, "target": "weapon_id"},
             "TurnSpeed": None, #homign pack
             "CruiseHeightRange": None,
             "CruiseRollSeconds": None,
@@ -564,7 +568,7 @@ class Ability(Object):
         return data["Properties"]
     
     def _p_actor_class(self, data):
-        return p_actor_class(self, data) #wrapper that makes it use Ability class
+        return p_actor_class(data)
     
     def _p_movement_component(self, data):
         return p_movement_component(data)
@@ -756,7 +760,7 @@ def p_buffs(data: dict):
         }
 
         buff_asset_path = buff["Key"]
-        buff_data = p_actor_class(Ability(), buff_asset_path)
+        buff_data = p_actor_class(buff_asset_path)
         if buff_data:
             parsed_buff.update(buff_data)
 
@@ -799,10 +803,10 @@ def p_ability_classes(data: dict):
         ids.append(ability_id)
     return ids
 
-def p_actor_class(obj, data: dict):
+def p_actor_class(data: dict):
     if type(data) is list:
         for elem in data:
-            return p_actor_class(obj, elem)
+            return p_actor_class(elem)
     elif type(data) is dict:
         data = asset_path_to_data(data["ObjectPath"])
     elif type(data) is str:
@@ -988,12 +992,12 @@ def p_actor_class(obj, data: dict):
         "FocusComponent": p_focus_component,
         "PassiveWeaponComponent": None, #contains no data
         "SoundSystemComponent": None,
-        "WeaponInfos": {"parser": p_weapon_infos, "action": ParseAction.ATTRIBUTE, "target": "weapon"},
+        "WeaponInfos": p_weapon_infos,
         "EnemyMaterialInstance": None,
         "FriendMaterialInstance": None,
         "bCanBeDamaged": "value",
         "ActiveRadius": "value", #minefield
-        "BuffsOnHit": obj._p_actor_class,
+        "BuffsOnHit": p_actor_class,
         "SingleExplosionSoundEvent": None,
         "FinalExplosionSoundEvent": None,
         "MineNiagaraEffect": None,
@@ -1019,7 +1023,7 @@ def p_actor_class(obj, data: dict):
         "TransfusionRayFx": None,
         "SpawnSoundEvent": None,
         "Harpoon Shot Delay": "value", #snare
-        "Snare Debuff": obj._p_actor_class,
+        "Snare Debuff": p_actor_class,
         "Harpoon Direct Damage": "value",
         "Snap Object Types": None,
         "Death VFX": None,
@@ -1042,7 +1046,7 @@ def p_actor_class(obj, data: dict):
         "StartHealingSoundEvent": None,
         "StopHealingSoundEvent": None,
         "FriendlyColor": None,
-        "Buff": obj._p_actor_class,
+        "Buff": p_actor_class,
         "WasSpottedSoundEvent": None, #echo burst
         "SpottedSoundEvent": None,
         "bIndestructible": "value", #ares torso
@@ -1064,7 +1068,7 @@ def p_actor_class(obj, data: dict):
         "SocketToFX_ColorId": None,
     }
 
-    parsed_data = obj._process_key_to_parser_function(
+    parsed_data = process_key_to_parser_function(
         key_to_parser_function, props, log_descriptor="ActorClass", tabs=5, set_attrs=False, default_configuration={
             'target': ParseTarget.MATCH_KEY
         }

--- a/src/parsers/character_module.py
+++ b/src/parsers/character_module.py
@@ -343,7 +343,7 @@ class CharacterModule(Object):
         self.reload_type = parse_colon_colon(data)  # ESWeaponReloadType::X -> X
 
     def _p_actor_class(self, data):
-        return p_actor_class(self, data)
+        return p_actor_class(data)
 
     def _p_projectile_mappings(self, data):
         parsed_mappings = []

--- a/src/parsers/character_module.py
+++ b/src/parsers/character_module.py
@@ -3,9 +3,9 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from parsers.object import Object, ParseTarget
+from parsers.object import Object
 from parsers.ability import Ability, p_movement_component, p_collision_component, p_actor_class
-from utils import log, asset_path_to_data, parse_colon_colon, parse_editor_curve_data, merge_dicts
+from utils import ParseTarget, asset_path_to_data, parse_colon_colon, parse_editor_curve_data, merge_dicts
 
 class CharacterModule(Object):
     objects = dict()  # Dictionary to hold all CharacterModule instances

--- a/src/parsers/game_mode.py
+++ b/src/parsers/game_mode.py
@@ -3,10 +3,10 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from utils import parse_colon_colon, log, get_json_data, asset_path_to_file_path_and_index, asset_path_to_data, path_to_id, asset_path_to_file_path, PARAMS, parse_editor_curve_data
+from utils import ParseTarget, parse_colon_colon, log, get_json_data, asset_path_to_file_path_and_index, asset_path_to_data, path_to_id, asset_path_to_file_path, PARAMS, parse_editor_curve_data
 from parsers.localization_table import parse_localization
 
-from parsers.object import Object, ParseTarget
+from parsers.object import Object
 from parsers.ability import p_actor_class
 from parsers.bot_names import BotNames
 from parsers.honor_reward import HonorReward

--- a/src/parsers/game_mode.py
+++ b/src/parsers/game_mode.py
@@ -112,7 +112,7 @@ class GameMode(Object):
         return parsed_data
         
     def _p_actor_class(self, data):
-        return p_actor_class(self, data) #calls global p_actor_class and passes the object to use
+        return p_actor_class(data)
 
     def _p_titan_settings(self, data):
         data = asset_path_to_data(data["ObjectPath"])["Properties"]

--- a/src/parsers/object.py
+++ b/src/parsers/object.py
@@ -3,7 +3,7 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from utils import PARAMS, path_to_id, asset_path_to_file_path_and_index, get_json_data, log, to_snake_case, merge_dicts, asset_path_to_data
+from utils import PARAMS, path_to_id, asset_path_to_file_path_and_index, get_json_data, log, merge_dicts, asset_path_to_data, process_key_to_parser_function
 
 import json
 
@@ -27,159 +27,18 @@ class Object: #generic object that all classes extend
 
     def _process_key_to_parser_function(self, key_to_parser_function_map, data, log_descriptor="", set_attrs=True, tabs=0, default_configuration={}):
         """
-        Enhanced version that supports flexible target destinations.
-        
-        Configuration format:
-        {
-            "PropertyKey": {
-                'parser': function_or_value,     # Optional: Parser function or "value" (default: "value")
-                'action': ParseAction.ATTRIBUTE, # Optional: How to store the result (default: ParseAction.ATTRIBUTE)
-                'target_dict_path': 'dict.nested', # Dict path with dot notation (only for DICT_ENTRY action)
-                'target': ParseTarget.MATCH_KEY or "custom_name", # How to determine the key/attribute name
-            }
-
-            OR any of the following shortcuts:
-            "PropertyKey": function or "value" # Will default to ParseAction.ATTRIBUTE and ParseTarget.MATCH_KEY_SNAKE
-
-            "PropertyKey": (function, "key")  # Use function to parse and store as "key" - legacy format. Only needed over the above shortcut if key needs to be different to snake case.
-        }
-        
-        Examples:
-        "Regen amount": {
-            'action': ParseAction.DICT_ENTRY,
-            'target_dict_path': 'default_properties',
-            'target': ParseTarget.MATCH_KEY,  # saves to self.default_properties["Regen amount"]
-        },
-        "DamageBoost": {
-            'action': ParseAction.DICT_ENTRY,
-            'target_dict_path': 'default_properties',
-            'target': "damage_boost",  # saves to self.default_properties["damage_boost"]
-        },
-        "Stats": {
-            'parser': self._p_stats,
-            'target': "parsed_stats",  # saves to self.parsed_stats
-        }
+        Wrapper method that calls the utility function with self as the object.
         """
-        
-        if not isinstance(key_to_parser_function_map, dict):
-            raise TypeError("key_to_parser_function must be a dictionary.")
-        
-        if log_descriptor != "":
-            log_descriptor = f" in {log_descriptor}"
+        return process_key_to_parser_function(
+            key_to_parser_function_map=key_to_parser_function_map,
+            data=data,
+            obj=self,
+            log_descriptor=log_descriptor,
+            set_attrs=set_attrs,
+            tabs=tabs,
+            default_configuration=default_configuration
+        )
 
-        # Determine the default configuration
-        default_config_to_use = {
-            'parser': "value",  # Default parser is "value"
-            'action': ParseAction.ATTRIBUTE,  # Default action is to set an attribute
-            'target_dict_path': None,  # Default is no nested dict path
-            'target': ParseTarget.MATCH_KEY_SNAKE  # Default target is to match key in snake_case
-        }
-        # Update with any provided default configuration
-        for key, value in default_configuration.items():
-            if key in default_config_to_use:
-                default_config_to_use[key] = value
-            else:
-                raise ValueError(f"Unknown default configuration key: {key}")
-            
-        parsed_data = dict()
-
-        for key, value in data.items():
-            if key in key_to_parser_function_map:
-                config = key_to_parser_function_map[key]
-                
-                # Handle None (skip processing)
-                if config is None:
-                    continue
-                
-                # Handle function directly - use as parser with defaults
-                if callable(config) or config == "value":
-                    config = {
-                        'parser': config,
-                    }
-                
-                # Handle legacy tuple format for backwards compatibility
-                elif isinstance(config, tuple):
-                    config = {
-                        'parser': config[0],
-                        'target': config[1]
-                    }
-                
-                # Handle new dictionary format
-                if not isinstance(config, dict):
-                    raise TypeError(f"{self.__class__.__name__} Value for key '{key}' must be a dict, tuple, callable, or None, got {type(config)}")
-
-                parser = config.get('parser', default_config_to_use['parser'])
-                action = config.get('action', default_config_to_use['action'])
-                target_dict_path = config.get('target_dict_path', default_config_to_use['target_dict_path'])
-                target = config.get('target', default_config_to_use['target'])
-                
-                # Validate configuration
-                if action == ParseAction.DICT_ENTRY and not target_dict_path:
-                    raise ValueError(f"{self.__class__.__name__} target_dict_path required for DICT_ENTRY action on key '{key}'")
-                elif action == ParseAction.ATTRIBUTE and target_dict_path:
-                    #raise ValueError(f"{self.__class__.__name__} target_dict_path should not be provided for ATTRIBUTE action on key '{key}'")
-                    # this is now allowed for defaulting it in configuration. Its simply ignored if not DICT_ENTRY
-                    pass
-                
-                # Parse the value
-                if parser == "value":
-                    parsed_value = value
-                elif callable(parser):
-                    parsed_value = parser(value)
-                else:
-                    raise TypeError(f"{self.__class__.__name__} Parser for key '{key}' must be callable or 'value', got {type(parser)}")
-                
-                if parsed_value is None:
-                    continue
-                
-                # Determine target name
-                if target == ParseTarget.MATCH_KEY:
-                    target_name = key
-                elif target == ParseTarget.MATCH_KEY_SNAKE:
-                    target_name = to_snake_case(key)
-                elif isinstance(target, str):
-                    # Custom string target
-                    target_name = target
-                else:
-                    raise ValueError(f"{self.__class__.__name__} Target must be ParseTarget.MATCH_KEY, ParseTarget.MATCH_KEY_SNAKE, or a string for key '{key}', got {type(target)}")
-                
-                # Store the parsed value
-                if action == ParseAction.ATTRIBUTE:
-                    # Direct attribute assignment
-                    if set_attrs:
-                        setattr(self, target_name, parsed_value)
-                    else:
-                        parsed_data[target_name] = parsed_value
-                        
-                elif action == ParseAction.DICT_ENTRY:
-                    # Handle dot notation for nested dictionaries
-                    path_parts = target_dict_path.split('.')
-                    
-                    if set_attrs:
-                        current = self
-                        # Navigate/create the nested structure
-                        for part in path_parts:
-                            if not hasattr(current, part):
-                                setattr(current, part, {})
-                            current = getattr(current, part)
-                        current[target_name] = parsed_value
-                    else:
-                        # For non-attribute setting, store in nested structure
-                        current = parsed_data
-                        for part in path_parts[:-1]:
-                            if part not in current:
-                                current[part] = {}
-                            current = current[part]
-                        if path_parts[-1] not in current:
-                            current[path_parts[-1]] = {}
-                        current[path_parts[-1]][target_name] = parsed_value
-            
-            else:
-                log(f"Warning: {self.__class__.__name__} {self.id} has unknown property '{key}'{log_descriptor}", tabs=tabs)
-
-        if not set_attrs:
-            return parsed_data
-        
     def _parse_from_data(source_data: dict):
         raise NotImplementedError("Subclasses must implement _parse_from_data to use _parse_and_merge_template()")
 
@@ -262,11 +121,3 @@ class Object: #generic object that all classes extend
         file_path = os.path.join(PARAMS.output_path, f'{cls.__name__}.json')
         with open(file_path, 'w', encoding='utf-8') as f:
             f.write(cls.to_json())
-
-class ParseAction:
-    ATTRIBUTE = "attribute"
-    DICT_ENTRY = "dict_entry"
-
-class ParseTarget:
-    MATCH_KEY = "match_key"           # Use the original key as-is
-    MATCH_KEY_SNAKE = "match_key_snake"  # Convert key to snake_case

--- a/src/parsers/pilot_talent.py
+++ b/src/parsers/pilot_talent.py
@@ -3,14 +3,13 @@ import sys
 import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from parsers.object import Object, ParseAction, ParseTarget
-
+from parsers.object import Object
 from parsers.localization_table import parse_localization
 from parsers.image import parse_image_asset_path
 from parsers.module_stat import ModuleStat
 from parsers.module_tag import ModuleTag
 
-from utils import asset_path_to_data, asset_path_to_file_path, get_json_data, parse_colon_colon
+from utils import ParseTarget, ParseAction, asset_path_to_data, asset_path_to_file_path, get_json_data, parse_colon_colon
 
 class PilotTalent(Object):
     objects = dict()  # Dictionary to hold all PilotTalent instances

--- a/src/parsers/powerup.py
+++ b/src/parsers/powerup.py
@@ -59,7 +59,7 @@ class Powerup(Object):
         return overlayed_data
 
     def _p_actor_class(self, data: dict):
-        return p_actor_class(self, data)
+        return p_actor_class(data)
 
 def parse_powerup_wrapper(full_path, id):
     if 'Indicator' in full_path:

--- a/src/utils.py
+++ b/src/utils.py
@@ -352,7 +352,7 @@ def process_key_to_parser_function(key_to_parser_function_map, data, obj=None, l
         log_descriptor = f" in {log_descriptor}"
 
     # Get class name for logging
-    class_name = obj.__class__.__name__ if obj else 'NoClass'
+    class_name = obj.__class__.__name__ if obj else None
 
     # Determine the default configuration
     default_config_to_use = {
@@ -462,8 +462,9 @@ def process_key_to_parser_function(key_to_parser_function_map, data, obj=None, l
                     current[path_parts[-1]][target_name] = parsed_value
         
         else:
-            obj_id = getattr(obj, 'id', 'unknown') if obj else 'unknown'
-            log(f"Warning: {class_name} {obj_id} has unknown property '{key}'{log_descriptor}", tabs=tabs)
+            obj_id = getattr(obj, 'id', 'Error, no id found for obj') if obj else None
+            obj_class_ref_str = f"{class_name} {obj_id} has unknown property" if class_name and obj_id else "Unknown property"
+            log(f"Warning process_key_to_parser_function(): {obj_class_ref_str} '{key}'{log_descriptor}", tabs=tabs)
 
     if not set_attrs:
         return parsed_data

--- a/src/utils.py
+++ b/src/utils.py
@@ -371,7 +371,17 @@ def process_key_to_parser_function(key_to_parser_function_map, data, obj=None, l
     parsed_data = dict()
 
     for key, value in data.items():
-        if key in key_to_parser_function_map:
+        # Remove trailing indexing from key if present
+        # i.e. 'Id_ColorParam[2]' -> 'Id_ColorParam'
+        if isinstance(key, str) and re.match(r'.+\[\d+\]$', key):
+            key = re.sub(r'\[\d+\]$', '', key)
+
+        if not key in key_to_parser_function_map:
+            obj_id = getattr(obj, 'id', 'Error, no id found for obj') if obj else None
+            obj_class_ref_str = f"{class_name} {obj_id} has unknown property" if class_name and obj_id else "Unknown property"
+            log(f"Warning process_key_to_parser_function(): {obj_class_ref_str} '{key}'{log_descriptor}", tabs=tabs)
+        
+        else:
             config = key_to_parser_function_map[key]
             
             # Handle None (skip processing)
@@ -460,11 +470,6 @@ def process_key_to_parser_function(key_to_parser_function_map, data, obj=None, l
                     if path_parts[-1] not in current:
                         current[path_parts[-1]] = {}
                     current[path_parts[-1]][target_name] = parsed_value
-        
-        else:
-            obj_id = getattr(obj, 'id', 'Error, no id found for obj') if obj else None
-            obj_class_ref_str = f"{class_name} {obj_id} has unknown property" if class_name and obj_id else "Unknown property"
-            log(f"Warning process_key_to_parser_function(): {obj_class_ref_str} '{key}'{log_descriptor}", tabs=tabs)
 
     if not set_attrs:
         return parsed_data


### PR DESCRIPTION
Object._process_key_to_parser_function logic moved to a util process_key_to_parser_function where passing an object is optional. Object now calls it and passes the object

If object is not provided, warnings are now:
`Warning process_key_to_parser_function(): Unknown property 'CountStack[2]' in ActorClass`

If object is provided, warnings are:
`Warning process_key_to_parser_function(): Ability BP_Module_Raven_Torso.1 has unknown property 'ColorIdParam[1]' in ProjectileType`