### PR TITLE
Char preset fix

### DIFF
--- a/src/parse/analysis.py
+++ b/src/parse/analysis.py
@@ -656,7 +656,7 @@ class Analysis:
             fpreset_ref = fpreset.to_ref()
             if not hasattr(fpreset, 'is_factory_preset') or not fpreset.is_factory_preset: #only look at factory presets, as character presets includes ai bots
                 continue
-            for module_socket_name, module_data in fpreset.modules.items():
+            for module_data in fpreset.modules:
                 module_ref = module_data['module_ref']
                 this_module_upgrade_costs, module_category_ref = self.get_module_upgrade_costs(module_ref, standard_cost_and_scrap)
 

--- a/src/parse/parsers/bot_ai_preset.py
+++ b/src/parse/parsers/bot_ai_preset.py
@@ -37,16 +37,12 @@ def parse_bot_ai_presets(to_file=False):
     root_data = get_json_data(root_path, index=0)
     props = root_data["Properties"]
 
-    # Older version only has by-level in BotPresets
     # Newer version (as of 2025-09-09) has both by-level and by-league
-    if "BotPresets" in props:
-        bot_presets_by_level = props["BotPresets"]
-        bot_presets_by_league = []
-    elif "DedicatedBotPresets" in props:
+    if "DedicatedBotPresets" in props:
         bot_presets_by_level = props["DedicatedBotPresets"]["BotPresetsByLevel"]
         bot_presets_by_league = props["DedicatedBotPresets"]["BotPresetByLeague"]
     else:
-        raise ValueError("Neither 'BotPresets' nor 'DedicatedBotPresets' found in root properties.")
+        raise ValueError("'DedicatedBotPresets' not found in root properties.")
     
     for bot_preset_entry in bot_presets_by_level:
         level = bot_preset_entry["Key"]

--- a/src/parse/parsers/character_preset.py
+++ b/src/parse/parsers/character_preset.py
@@ -44,21 +44,17 @@ class CharacterPreset(ParseObject):
             self.character_type = "Mech"
 
     def _p_modules(self, data):
-        modules = {}
-        for index, module_entry in enumerate(data):
+        modules = []
+        for module_entry in data:
             module_ref = Module.create_from_asset(module_entry["Module"], sub_index=False).to_ref()
             socket_name = module_entry["ParentSocket"]
             parent_socket_index = module_entry["ParentModuleIndex"]
-            # determine parent_socket_name by using the parent_socket_index lookup in modules
-            if parent_socket_index == -1:
-                parent_socket_name = None
-            else:
-                parent_socket_name = list(modules.keys())[parent_socket_index]
-            modules[socket_name] = {
+            modules.append({
                 "module_ref": module_ref,
-                "parent_socket_name": parent_socket_name,
+                "socket_name": socket_name,
+                "parent_socket_index": parent_socket_index,
                 "level": module_entry["Level"]
-            }
+            })
         return modules
     
     def _p_pilot(self, data):


### PR DESCRIPTION
* Remove unneeded backwards compatibility for bot presets now that we no longer support versioning
* Character preset's list of modules is now an array instead of a dictionary, where each module socket references other sockets by the index in the array instead of a key, as the socket_name was used as a key and there were duplicate socket_names.
* Analysis updated to support the new structure