### PR TITLE
Post enrichment fixes

### DIFF
--- a/src/parse/enrichment.py
+++ b/src/parse/enrichment.py
@@ -15,12 +15,6 @@ from parsers.localization import Localization
 from parsers.virtual_bot import VirtualBot
 from parsers.module_group import ModuleGroup
 
-CORE_MODULE_CATEGORIES = [
-    'DA_ModuleCategory_Chassis.0',
-    'DA_ModuleCategory_Torso.0',
-    'DA_ModuleCategory_Shoulder.0',
-]
-
 PILOT_TYPE_LEGENDARY_REF = 'OBJID_PilotType::DA_PilotType_Legendary.0'
 
 def slugify(text: str) -> str:
@@ -41,17 +35,22 @@ def ref_to_id(ref):
         return ref
     return ref.split('::')[1]
 
-def is_core_module(module):
+def is_virtual_bot_module(module):
     module_type_ref = getattr(module, 'module_type_ref', None)
     if not module_type_ref:
         return False
     
-    module_type = ModuleType.get_from_ref(module_type_ref)
-    if not module_type or not hasattr(module_type, 'module_category_ref'):
+    # Get the module group for this module type
+    group_id = ModuleGroup.get_group_id_for_type(ref_to_id(module_type_ref))
+    if not group_id:
         return False
     
-    category_id = ref_to_id(module_type.module_category_ref)
-    return category_id in CORE_MODULE_CATEGORIES
+    # Check if this module group is marked as a virtual bot module
+    module_group = ModuleGroup.objects.get(group_id)
+    if not module_group:
+        return False
+    
+    return getattr(module_group, 'virtual_bot_module', False)
 
 def enrich():
     logger.info("Starting enrichment phase...")
@@ -85,9 +84,9 @@ def enrich_modules_with_bots():
     module_id_to_sides = {} # {module_id: set(['L', 'R'])}
     virtual_bots = {}
 
-    all_core_module_ids = [id for id, m in Module.objects.items() if is_core_module(m)]
+    all_virtual_bot_module_ids = [id for id, m in Module.objects.items() if is_virtual_bot_module(m)]
 
-    for module_id in all_core_module_ids:
+    for module_id in all_virtual_bot_module_ids:
         if module_id in core_module_to_bot_id:
             continue
 
@@ -104,10 +103,10 @@ def enrich_modules_with_bots():
             bot_name_str = get_default_string(preset.name) or first_preset_id
             bot_id = slugify(bot_name_str)
 
-            # Map all core modules in this preset to this bot_id
+            # Map all virtual bot modules in this preset to this bot_id
             for m_data in preset.modules:
                 m_id = ref_to_id(m_data['module_ref'])
-                if m_id in Module.objects and is_core_module(Module.objects[m_id]):
+                if m_id in Module.objects and is_virtual_bot_module(Module.objects[m_id]):
                     if m_id not in core_module_to_bot_id:
                         core_module_to_bot_id[m_id] = bot_id
 
@@ -127,10 +126,10 @@ def enrich_modules_with_bots():
                     icon_path=getattr(preset, 'icon', None)
                 )
 
-            # Add core modules to bot
+            # Add virtual bot modules to bot
             for m_data in preset.modules:
                 m_id = ref_to_id(m_data['module_ref'])
-                if m_id in Module.objects and is_core_module(Module.objects[m_id]):
+                if m_id in Module.objects and is_virtual_bot_module(Module.objects[m_id]):
                     m_ref = Module.id_to_ref(m_id)
                     if m_ref not in virtual_bots[bot_id].core_module_refs:
                         virtual_bots[bot_id].core_module_refs.append(m_ref)

--- a/src/parse/enrichment.py
+++ b/src/parse/enrichment.py
@@ -14,6 +14,8 @@ from parsers.pilot_talent import PilotTalent
 from parsers.localization import Localization
 from parsers.virtual_bot import VirtualBot
 from parsers.module_group import ModuleGroup
+from parsers.bot_ai_preset import BotAIPreset
+from parsers.drop_team import DropTeam
 
 PILOT_TYPE_LEGENDARY_REF = 'OBJID_PilotType::DA_PilotType_Legendary.0'
 
@@ -154,6 +156,52 @@ def enrich_modules_with_bots():
             preset_ref = CharacterPreset.id_to_ref(pid)
             if preset_ref not in virtual_bots[assigned_bot_id].factory_preset_refs:
                 virtual_bots[assigned_bot_id].factory_preset_refs.append(preset_ref)
+
+    # Check AI bots for titan weapons and add them to corresponding virtual bots
+    logger.info("Checking AI bots for titan weapons...")
+    logger.info(f"Found {len(BotAIPreset.objects)} AI bots")
+    
+    for bot_ai in BotAIPreset.objects.values():
+        if not hasattr(bot_ai, 'drop_teams_refs'):
+            continue
+            
+        for drop_team_ref in bot_ai.drop_teams_refs:
+            drop_team_id = ref_to_id(drop_team_ref)
+            drop_team = DropTeam.objects.get(drop_team_id)
+            
+            if not drop_team or not hasattr(drop_team, 'character_presets_refs'):
+                continue
+                
+            # Find character presets in this drop team
+            for preset_ref in drop_team.character_presets_refs:
+                preset_id = ref_to_id(preset_ref)
+                preset = CharacterPreset.objects.get(preset_id)
+                
+                if not preset or getattr(preset, 'is_factory_preset', False):
+                    continue
+                    
+                # Check if this preset has titan weapons
+                bot_name = get_default_string(preset.name) or preset_id
+                bot_slug = slugify(bot_name)
+                
+                # Look for titan weapons in this preset
+                for m_data in preset.modules:
+                    m_id = ref_to_id(m_data['module_ref'])
+                    if m_id in Module.objects:
+                        module = Module.objects[m_id]
+                        module_type_ref = getattr(module, 'module_type_ref', None)
+                        if module_type_ref:
+                            type_id = ref_to_id(module_type_ref)
+                            group_id = ModuleGroup.get_group_id_for_type(type_id)
+                            if group_id == 'titan-weapon':
+                                # Find the virtual bot with the same name
+                                if bot_slug in virtual_bots:
+                                    m_ref = Module.id_to_ref(m_id)
+                                    if m_ref not in virtual_bots[bot_slug].core_module_refs:
+                                        virtual_bots[bot_slug].core_module_refs.append(m_ref)
+                                        # Also update the core_module_to_bot_id mapping
+                                        core_module_to_bot_id[m_id] = bot_slug
+                                        logger.info(f"Added titan weapon {m_id} to virtual bot {bot_slug} from AI bot {bot_name}")
 
     # Finally, enrich Module objects with virtual_bot_ref and shoulder_side
     for module_id, module in Module.objects.items():

--- a/src/parse/enrichment.py
+++ b/src/parse/enrichment.py
@@ -14,7 +14,6 @@ from parsers.pilot_talent import PilotTalent
 from parsers.localization import Localization
 from parsers.virtual_bot import VirtualBot
 from parsers.module_group import ModuleGroup
-from parsers.object import ParseObject
 
 CORE_MODULE_CATEGORIES = [
     'DA_ModuleCategory_Chassis.0',

--- a/src/parse/parse.py
+++ b/src/parse/parse.py
@@ -19,7 +19,7 @@ from parsers.localization import *
 from parsers.pilot import *
 from parsers.progression_table import *
 from parsers.game_mode import *
-from parse.parsers.bot_ai_preset import *
+from parsers.bot_ai_preset import *
 from parsers.character_preset import *
 from parsers.powerup import *
 from analysis import *

--- a/src/parse/parsers/bot_ai_preset.py
+++ b/src/parse/parsers/bot_ai_preset.py
@@ -56,7 +56,6 @@ def parse_bot_ai_presets(to_file=False):
     # parse the league-array
     for bot_preset_entry in bot_presets_by_league:
         league_asset_path = bot_preset_entry["Key"]
-        logger.debug(f"Found league path {league_asset_path}")
         league_ref = League.create_from_asset_path(league_asset_path).to_ref() # Just to validate it exists
         bot_preset = BotAIPreset.create_from_asset(bot_preset_entry["Value"])
         # Ensure it doesn't already have a league

--- a/src/parse/parsers/module_group.py
+++ b/src/parse/parsers/module_group.py
@@ -66,7 +66,7 @@ MODULE_TYPE_TO_GROUP = {
     'DA_ModuleType_Ability4.0': 'cycle-gear',
 }
 
-MODULE_GROUPS_DATA = {
+MODULE_GROUPS_DATA = { #english translation is added here in enrichment.py
     'titan-torsos': {
         'name': {'Key': 'CMP_Type_Titan_Torso', 'TableNamespace': 'Component_Tags'},
         'titan': True,
@@ -75,8 +75,8 @@ MODULE_GROUPS_DATA = {
         'name': {'Key': 'CMP_Type_Titan_Chassis', 'TableNamespace': 'Component_Tags'},
         'titan': True,
     },
-    'titan-shoulder': {
-        'name': {'Key': 'GRP_TitanShoulders_Name', 'TableNamespace': 'ModuleGroups'},
+    'titan-shoulder': { #except for this one because the translation is on the Site. Shortsight unfortunately. Realistically this is only used for the slug map anyways.
+        'name': {'Key': 'GRP_TitanShoulders_Name', 'TableNamespace': 'ModuleGroups', 'en': 'Titan Shoulder'},
         'titan': True,
     },
     'titan-weapon': {

--- a/src/parse/parsers/module_group.py
+++ b/src/parse/parsers/module_group.py
@@ -70,27 +70,34 @@ MODULE_GROUPS_DATA = { #english translation is added here in enrichment.py
     'titan-torsos': {
         'name': {'Key': 'CMP_Type_Titan_Torso', 'TableNamespace': 'Component_Tags'},
         'titan': True,
+        'virtual_bot_module': True,
     },
     'titan-chassis': {
         'name': {'Key': 'CMP_Type_Titan_Chassis', 'TableNamespace': 'Component_Tags'},
         'titan': True,
+        'virtual_bot_module': True,
     },
     'titan-shoulder': { #except for this one because the translation is on the Site. Shortsight unfortunately. Realistically this is only used for the slug map anyways.
         'name': {'Key': 'GRP_TitanShoulders_Name', 'TableNamespace': 'ModuleGroups', 'en': 'Titan Shoulder'},
         'titan': True,
+        'virtual_bot_module': True,
     },
     'titan-weapon': {
         'name': {'Key': 'CMP_Type_Titan_Weapon', 'TableNamespace': 'Component_Tags'},
         'titan': True,
+        'virtual_bot_module': True,
     },
     'non-titan-torsos': {
         'name': {'Key': 'HNG_Torso', 'TableNamespace': 'Component_Tags'},
+        'virtual_bot_module': True,
     },
     'non-titan-chassis': {
         'name': {'Key': 'HNG_Chassis', 'TableNamespace': 'Component_Tags'},
+        'virtual_bot_module': True,
     },
     'non-titan-shoulder': {
         'name': {'Key': 'HNG_Shoulder', 'TableNamespace': 'Component_Tags'},
+        'virtual_bot_module': True,
     },
     'heavy-weapon': {
         'name': {'Key': 'HNG_HeavyWeapon', 'TableNamespace': 'Component_Tags'},
@@ -109,12 +116,13 @@ MODULE_GROUPS_DATA = { #english translation is added here in enrichment.py
 class ModuleGroup(ParseObject):
     objects = dict()
     
-    def __init__(self, id, name, sort_order, titan, description=None):
+    def __init__(self, id, name, sort_order, titan, virtual_bot_module=False, description=None):
         super().__init__(id)
         self.id = id
         self.name = name
         self.sort_order = sort_order
         self.titan = titan
+        self.virtual_bot_module = virtual_bot_module
         if description:
             self.description = description
 
@@ -154,6 +162,7 @@ class ModuleGroup(ParseObject):
                 name=data['name'],
                 sort_order=index,
                 titan=data.get('titan', False),
+                virtual_bot_module=data.get('virtual_bot_module', False),
                 description=desc
             )
 

--- a/src/parse/parsers/virtual_bot.py
+++ b/src/parse/parsers/virtual_bot.py
@@ -8,9 +8,9 @@ from parsers.object import ParseObject
 """
 Virtual Bot represents the a robot the way its referenced by the community.
 
-"Woah that new Garuda bot looks awesome!" -> refers to the modules that are specific to Garuda, i.e. the core modules, Torso, Chassis, Shoulder(s)
+"Woah that new Garuda bot looks awesome!" -> refers to the modules that are specific to Garuda, i.e. the virtual bot modules, Torso, Chassis, Shoulder(s), and Titan Weapon
 
-Virtual Bot would be named Garuda. In addition to storing the core modules, it would specify if it has two different shoulders (like titans) and factory presets that use these 3 core modules.
+Virtual Bot would be named Garuda. In addition to storing the virtual bot modules, it would specify if it has two different shoulders (like titans) and factory presets that use these virtual bot modules.
 """
 
 class VirtualBot(ParseObject):


### PR DESCRIPTION
# Refactor Virtual Bot Module Detection & Add AI Bot Titan Weapon Support

## Summary
- Refactors core module detection from module categories to module groups for more flexible virtual bot module identification
- Successfully implements AI bot logic to automatically associate titan weapons with corresponding virtual bots based on name matching
- Fixes module group enrichment for titan-shoulder group with inline English translation

## Key Changes
- **Module Group System**: Replaced `CORE_MODULE_CATEGORIES` with `virtual_bot_module` attribute in module group definitions
- **Virtual Bot Modules**: Now includes titan weapons alongside torsos, chassis, and shoulders
- **AI Bot Integration**: Scans AI bot presets for titan weapons and adds them to matching virtual bots (e.g., Alpha AI bot with Bayonet weapon adds Bayonet to Alpha virtual bot)
- **Translation Fix**: Added inline English translation for titan-shoulder module group

## Technical Details
- Updated `is_core_module` → `is_virtual_bot_module` using module groups
- Fixed import path for BotAIPreset parsing
- Enhanced enrichment logic to traverse BotAIPreset → DropTeam → CharacterPreset relationships
- Successfully verified Bayonet weapon now appears in Alpha virtual bot

## Impact
- More accurate virtual bot module identification
- Automatic titan weapon association from AI bots
- Improved module group enrichment system
