### PR TITLE
Fix/CharacterClass description field

### DIFF
--- a/src/parse/parsers/character_class.py
+++ b/src/parse/parsers/character_class.py
@@ -19,7 +19,7 @@ class CharacterClass(ParseObject):
             "ImageBig": (parse_image_asset_path, "image_big_path"),
             "ImageSmall": (parse_image_asset_path, "image_small_path"),
             "Name": parse_localization,
-            "Description": "value",
+            "Description": parse_localization,
             "Priority": None,
             "TutorialTag": None,
             "ID": None,


### PR DESCRIPTION
CharacterClass' description field was accidentally matching source data instead of being processed through the usual localization parsing, wherein it had the wrong schema when arriving at the frontend.