### PR TITLE
Implement ShopCard parser

### DIFF
--- a/src/parse/parse.py
+++ b/src/parse/parse.py
@@ -26,6 +26,7 @@ from analysis import *
 from enrichment import enrich
 from parsers.virtual_bot import VirtualBot
 from parsers.module_group import ModuleGroup
+from parsers.shop_card import ShopCard, parse_shop_cards
 
 def main():
     """Main parsing function - uses global OPTIONS singleton."""
@@ -40,6 +41,7 @@ def main():
     parse_bot_ai_presets()
     parse_factory_presets()
     parse_powerups()
+    parse_shop_cards()
     analyze()
     enrich()
 
@@ -95,6 +97,7 @@ def main():
     VirtualBot.to_file()
 
     Powerup.to_file()
+    ShopCard.to_file()
 
     Localization.to_file()
     Image.to_file()

--- a/src/parse/parsers/shop_card.py
+++ b/src/parse/parsers/shop_card.py
@@ -26,13 +26,12 @@ class ShopCard(ParseObject):
         self.height = data.get("Y")
 
     def _parse_backgrounds(self, data):
-        backgrounds = {}
+        backgrounds = []
         for entry in data:
-            raw_key = entry.get("Key")
             raw_value = entry.get("Value")
-            if raw_key and raw_value:
+            if raw_value:
                 image_path = parse_image_asset_path(raw_value)
-                backgrounds[raw_key] = image_path
+                backgrounds.append(image_path)
         self.backgrounds = backgrounds
 
 def parse_shop_cards(to_file=False):
@@ -63,7 +62,11 @@ def parse_shop_cards(to_file=False):
         if enum_key and asset_ref:
             shop_card = ShopCard.create_from_asset(asset_ref)
             if shop_card:
-                shop_card.size_type = parse_colon_colon(enum_key)
+                if not getattr(shop_card, "backgrounds", None):
+                    if shop_card.id in ShopCard.objects:
+                        del ShopCard.objects[shop_card.id]
+                else:
+                    shop_card.size_type = parse_colon_colon(enum_key)
 
     if to_file:
         ShopCard.to_file()

--- a/src/parse/parsers/shop_card.py
+++ b/src/parse/parsers/shop_card.py
@@ -1,0 +1,73 @@
+# Add two levels of parent dirs to sys path
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from parsers.object import ParseObject
+from parsers.image import parse_image_asset_path, Image
+from utils import OPTIONS, get_json_data, parse_colon_colon
+
+class ShopCard(ParseObject):
+    objects = dict()  # Dictionary to hold all ShopCard instances
+
+    def _parse(self):
+        props = self.source_data.get("Properties", {})
+
+        key_to_parser_function = {
+            "Size": self._parse_size,
+            "Backgrounds": self._parse_backgrounds,
+        }
+
+        self._process_key_to_parser_function(key_to_parser_function, props)
+
+    def _parse_size(self, data):
+        self.width = data.get("X")
+        self.height = data.get("Y")
+
+    def _parse_backgrounds(self, data):
+        backgrounds = {}
+        for entry in data:
+            raw_key = entry.get("Key")
+            raw_value = entry.get("Value")
+            if raw_key and raw_value:
+                image_path = parse_image_asset_path(raw_value)
+                backgrounds[raw_key] = image_path
+        self.backgrounds = backgrounds
+
+def parse_shop_cards(to_file=False):
+    file_path = os.path.join(OPTIONS.export_dir, r"WRFrontiers\Content\Sparrow\UI\Screens\Offers\WBP_CommonOfferCard.json")
+    
+    if not os.path.exists(file_path):
+        return
+
+    data = get_json_data(file_path)
+    
+    # Find the default object
+    default_obj = None
+    for item in data:
+        if item.get("Type") == "WBP_CommonOfferCard_C" and item.get("Name", "").startswith("Default__"):
+            default_obj = item
+            break
+            
+    if not default_obj:
+        return
+        
+    props = default_obj.get("Properties", {})
+    card_sizes = props.get("CardSizes", [])
+    
+    for entry in card_sizes:
+        enum_key = entry.get("Key")
+        asset_ref = entry.get("Value")
+        
+        if enum_key and asset_ref:
+            shop_card = ShopCard.create_from_asset(asset_ref)
+            if shop_card:
+                shop_card.size_type = parse_colon_colon(enum_key)
+
+    if to_file:
+        ShopCard.to_file()
+        Image.to_file()
+
+if __name__ == "__main__":
+    parse_shop_cards(to_file=True)


### PR DESCRIPTION
Implements the ShopCard parser to extract card size configurations from WBP_CommonOfferCard.json.

### Key Changes
- **ShopCard Parser Integration**: Extracts card size configurations (dimensions mapped to width/height) from the UI screen asset.
- **Background Filtering**: Only creates and persists ShopCard objects that have backgrounds defined.
- **Flat Backdrop Representation**: Parses backgrounds as a flat list of image asset paths, discarding the dictionary keys mapping to rarity assets.
- **Suffix Cleansing**: Cleaned up the size_type attribute by using parse_colon_colon (e.g., storing SH instead of ESShopItemSlotSize::SH).