### PR TITLE
ShopCard.backgrounds dict now includes rarity mapping

### DIFF
--- a/src/parse/parsers/shop_card.py
+++ b/src/parse/parsers/shop_card.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from parsers.object import ParseObject
 from parsers.image import parse_image_asset_path, Image
+from parsers.rarity import Rarity
 from utils import OPTIONS, get_json_data, parse_colon_colon
 
 class ShopCard(ParseObject):
@@ -26,12 +27,14 @@ class ShopCard(ParseObject):
         self.height = data.get("Y")
 
     def _parse_backgrounds(self, data):
-        backgrounds = []
+        backgrounds = {}
         for entry in data:
+            raw_key = entry.get("Key")
+            rarity_ref = Rarity.get_from_asset_path(raw_key)[1].to_ref()
             raw_value = entry.get("Value")
             if raw_value:
                 image_path = parse_image_asset_path(raw_value)
-                backgrounds.append(image_path)
+                backgrounds[rarity_ref] = image_path
         self.backgrounds = backgrounds
 
 def parse_shop_cards(to_file=False):


### PR DESCRIPTION
Added rarity mapping such that for a given rarity, the horizontal or vertical background for it can be found.

Old:
```json
"backgrounds": [
            "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Common_SH",
            "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Epic_SH",
            "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Legendary_SH",
            "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Rare_SH",
            "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Uncommon_SH"
]
```
New:
```json
"backgrounds": {
            "OBJID_Rarity::DA_Rarity_Common.0": "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Common_SH",
            "OBJID_Rarity::DA_Rarity_Epic.0": "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Epic_SH",
            "OBJID_Rarity::DA_Rarity_Legendary.0": "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Legendary_SH",
            "OBJID_Rarity::DA_Rarity_Rare.0": "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Rare_SH",
            "OBJID_Rarity::DA_Rarity_Uncommon.0": "/WRFrontiers/Content/Sparrow/UI/Textures/Meta/Offers/Backgrounds/T_Rarity_Uncommon_SH"
        },
```