### PR TITLE
Add the most exclusive ModuleSocketType to ModuleType matching

### DIFF
--- a/src/parse/enrichment.py
+++ b/src/parse/enrichment.py
@@ -17,6 +17,11 @@ from parsers.virtual_bot import VirtualBot
 from parsers.module_group import ModuleGroup
 from parsers.bot_ai_preset import BotAIPreset
 from parsers.drop_team import DropTeam
+from parsers.module_socket_type import ModuleSocketType
+from exclusive_module_socket_matching import (
+    ExclusiveAssignmentError,
+    resolve_exclusive_module_socket_assignments,
+)
 
 PILOT_TYPE_LEGENDARY_REF = 'OBJID_PilotType::DA_PilotType_Legendary.0'
 
@@ -68,14 +73,35 @@ def enrich():
             if group_id:
                 module.module_group_ref = ModuleGroup.id_to_ref(group_id)
 
-    # 2. Character Presets - Weapon Module Refs
+    # 2. Module socket exclusivity
+    enrich_module_socket_type_exclusivity()
+
+    # 3. Character Presets - Weapon Module Refs
     enrich_character_presets_with_weapon_refs()
 
-    # 3. Virtual Bots & Bot Refs
+    # 4. Virtual Bots & Bot Refs
     enrich_modules_with_bots()
 
-    # 4. Pilot Talents
+    # 5. Pilot Talents
     enrich_pilot_talents()
+
+def enrich_module_socket_type_exclusivity():
+    logger.info("Enriching module socket type exclusivity...")
+    socket_to_types = {}
+    for socket in ModuleSocketType.objects.values():
+        compatible_refs = getattr(socket, 'compatible_module_types_refs', None) or []
+        socket_to_types[socket.id] = {ref_to_id(ref) for ref in compatible_refs}
+
+    try:
+        socket_to_type, type_to_socket = resolve_exclusive_module_socket_assignments(socket_to_types)
+    except ExclusiveAssignmentError as exc:
+        logger.error(f"Failed to resolve exclusive module socket assignments: {exc}")
+        raise
+
+    for socket_id, type_id in socket_to_type.items():
+        ModuleSocketType.objects[socket_id].exclusive_module_type_ref = ModuleType.id_to_ref(type_id)
+    for type_id, socket_id in type_to_socket.items():
+        ModuleType.objects[type_id].exclusive_module_socket_type_ref = ModuleSocketType.id_to_ref(socket_id)
 
 def enrich_character_presets_with_weapon_refs():
     logger.info("Enriching character presets with weapon module refs...")

--- a/src/parse/exclusive_module_socket_matching.py
+++ b/src/parse/exclusive_module_socket_matching.py
@@ -1,0 +1,116 @@
+"""
+Exclusive ModuleSocketType ↔ ModuleType matching.
+
+Game data defines socket → compatible module types (1:many). This module derives a
+deterministic 1:1 "most exclusive" pairing in both directions by repeatedly
+assigning sockets that have only one remaining compatible type after already-
+assigned types are removed from each socket's pool.
+
+Algorithm (multi-pass until fixed point)
+----------------------------------------
+Each pass:
+  1. For every unassigned socket, compute:
+         remaining = compatible_types − {types already assigned to other sockets}
+  2. Assign any socket where len(remaining) == 1 to that sole type.
+  3. If a type would be assigned to two sockets, raise ExclusiveAssignmentError.
+  4. If any assignments were made, start another pass from step 1.
+  5. If no assignments were made and unassigned sockets remain, raise
+     ExclusiveAssignmentError (ambiguous or unsatisfiable data).
+
+Light / heavy weapon example
+----------------------------
+  light_socket  compatible: {Weapon}
+  heavy_socket  compatible: {Weapon, WeaponHeavy}
+
+  Pass 0: light_socket has one option → assign Weapon to light_socket.
+  Pass 1: heavy_socket pool becomes {WeaponHeavy} after pruning Weapon →
+          assign WeaponHeavy to heavy_socket.
+
+Reverse mapping: Weapon → light_socket, WeaponHeavy → heavy_socket.
+"""
+
+
+class ExclusiveAssignmentError(Exception):
+    """Raised when exclusive socket ↔ type assignment cannot be completed."""
+
+
+def resolve_exclusive_module_socket_assignments(
+    socket_to_compatible_type_ids: dict[str, set[str]],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """
+    Resolve a bidirectional 1:1 exclusive assignment between sockets and module types.
+
+    Args:
+        socket_to_compatible_type_ids: Maps socket id → set of compatible module type ids.
+
+    Returns:
+        (socket_id → type_id, type_id → socket_id)
+
+    Raises:
+        ExclusiveAssignmentError: If any socket cannot be uniquely assigned.
+    """
+    socket_to_type: dict[str, str] = {}
+    type_to_socket: dict[str, str] = {}
+
+    while True:
+        assigned_types = set(type_to_socket.keys())
+        progress = False
+
+        for socket_id, compatible_types in socket_to_compatible_type_ids.items():
+            if socket_id in socket_to_type:
+                continue
+
+            if not compatible_types:
+                raise ExclusiveAssignmentError(
+                    f"Socket '{socket_id}' has no compatible module types and cannot be assigned."
+                )
+
+            remaining = compatible_types - assigned_types
+
+            if len(remaining) == 0:
+                raise ExclusiveAssignmentError(
+                    f"Socket '{socket_id}' has no remaining compatible module types after "
+                    f"pruning already-assigned types. Compatible: {sorted(compatible_types)}, "
+                    f"already assigned: {sorted(assigned_types & compatible_types)}."
+                )
+
+            if len(remaining) != 1:
+                continue
+
+            type_id = next(iter(remaining))
+            if type_id in type_to_socket:
+                raise ExclusiveAssignmentError(
+                    f"Module type '{type_id}' would be assigned to both "
+                    f"'{type_to_socket[type_id]}' and '{socket_id}'."
+                )
+
+            socket_to_type[socket_id] = type_id
+            type_to_socket[type_id] = socket_id
+            progress = True
+
+        if progress:
+            continue
+
+        unassigned = [
+            socket_id
+            for socket_id in socket_to_compatible_type_ids
+            if socket_id not in socket_to_type
+        ]
+        if not unassigned:
+            break
+
+        unresolved = {}
+        for socket_id in unassigned:
+            remaining = socket_to_compatible_type_ids[socket_id] - set(type_to_socket.keys())
+            unresolved[socket_id] = sorted(remaining)
+
+        details = "; ".join(
+            f"{socket_id}: remaining {pools}"
+            for socket_id, pools in unresolved.items()
+        )
+        raise ExclusiveAssignmentError(
+            "Could not resolve exclusive module socket assignments. "
+            f"Unassigned sockets and their remaining compatible types: {details}"
+        )
+
+    return socket_to_type, type_to_socket

--- a/src/parse/exclusive_module_socket_matching.py
+++ b/src/parse/exclusive_module_socket_matching.py
@@ -2,19 +2,23 @@
 Exclusive ModuleSocketType ↔ ModuleType matching.
 
 Game data defines socket → compatible module types (1:many). This module derives a
-deterministic 1:1 "most exclusive" pairing in both directions by repeatedly
-assigning sockets that have only one remaining compatible type after already-
-assigned types are removed from each socket's pool.
+deterministic "most exclusive" pairing by repeatedly assigning sockets that have
+only one remaining compatible type after already-assigned types are removed from
+each socket's pool.
 
 Algorithm (multi-pass until fixed point)
 ----------------------------------------
 Each pass:
-  1. For every unassigned socket, compute:
+  1. For every unassigned socket with exactly one compatible type in game data,
+     assign that type (even if another socket already uses it). The reverse
+     type → socket map keeps the first socket encountered in input order.
+  2. For every other unassigned socket, compute:
          remaining = compatible_types − {types already assigned to other sockets}
-  2. Assign any socket where len(remaining) == 1 to that sole type.
-  3. If a type would be assigned to two sockets, raise ExclusiveAssignmentError.
-  4. If any assignments were made, start another pass from step 1.
-  5. If no assignments were made and unassigned sockets remain, raise
+  3. Assign any such socket where len(remaining) == 1 to that sole type.
+  4. If a multi-option socket would claim a type already assigned in this pass
+     to another multi-option socket, raise ExclusiveAssignmentError.
+  5. If any assignments were made, start another pass from step 1.
+  6. If no assignments were made and unassigned sockets remain, raise
      ExclusiveAssignmentError (ambiguous or unsatisfiable data).
 
 Light / heavy weapon example
@@ -27,6 +31,14 @@ Light / heavy weapon example
           assign WeaponHeavy to heavy_socket.
 
 Reverse mapping: Weapon → light_socket, WeaponHeavy → heavy_socket.
+
+Shoulder L / R example
+----------------------
+  shoulder_l_socket  compatible: {Shoulder}
+  shoulder_r_socket  compatible: {Shoulder}
+
+  Pass 0: both sockets have one option → assign Shoulder to each.
+  Reverse mapping: Shoulder → shoulder_l_socket (first in input order).
 """
 
 
@@ -38,7 +50,11 @@ def resolve_exclusive_module_socket_assignments(
     socket_to_compatible_type_ids: dict[str, set[str]],
 ) -> tuple[dict[str, str], dict[str, str]]:
     """
-    Resolve a bidirectional 1:1 exclusive assignment between sockets and module types.
+    Resolve exclusive assignments between sockets and module types.
+
+    Socket → type is many-to-one when multiple sockets share a single compatible
+    type (e.g. left/right shoulder). Type → socket is one-to-one and uses the
+    first socket in input order for shared types.
 
     Args:
         socket_to_compatible_type_ids: Maps socket id → set of compatible module type ids.
@@ -64,6 +80,14 @@ def resolve_exclusive_module_socket_assignments(
                 raise ExclusiveAssignmentError(
                     f"Socket '{socket_id}' has no compatible module types and cannot be assigned."
                 )
+
+            if len(compatible_types) == 1:
+                type_id = next(iter(compatible_types))
+                socket_to_type[socket_id] = type_id
+                if type_id not in type_to_socket:
+                    type_to_socket[type_id] = socket_id
+                progress = True
+                continue
 
             remaining = compatible_types - assigned_types
 

--- a/tests/test_parse/test_exclusive_module_socket_matching.py
+++ b/tests/test_parse/test_exclusive_module_socket_matching.py
@@ -1,0 +1,99 @@
+import importlib.util
+import os
+import sys
+import unittest
+
+os.environ['SHOULD_PARSE'] = 'false'
+os.environ.setdefault('EXPORT_DIR', '/tmp/test_export')
+os.environ.setdefault('OUTPUT_DIR', '/tmp/test_output')
+
+src_path = os.path.join(os.path.dirname(__file__), '..', '..', 'src')
+parse_path = os.path.join(src_path, 'parse')
+sys.path.insert(0, parse_path)
+
+spec = importlib.util.spec_from_file_location(
+    "exclusive_module_socket_matching",
+    os.path.join(parse_path, "exclusive_module_socket_matching.py"),
+)
+matching = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(matching)
+
+resolve_exclusive_module_socket_assignments = (
+    matching.resolve_exclusive_module_socket_assignments
+)
+ExclusiveAssignmentError = matching.ExclusiveAssignmentError
+
+
+class TestExclusiveModuleSocketMatching(unittest.TestCase):
+    def test_light_and_heavy_weapon_sockets(self):
+        socket_to_types = {
+            "light_socket": {"DA_ModuleType_Weapon.0"},
+            "heavy_socket": {"DA_ModuleType_Weapon.0", "DA_ModuleType_WeaponHeavy.0"},
+        }
+
+        socket_to_type, type_to_socket = resolve_exclusive_module_socket_assignments(
+            socket_to_types
+        )
+
+        self.assertEqual(socket_to_type["light_socket"], "DA_ModuleType_Weapon.0")
+        self.assertEqual(socket_to_type["heavy_socket"], "DA_ModuleType_WeaponHeavy.0")
+        self.assertEqual(type_to_socket["DA_ModuleType_Weapon.0"], "light_socket")
+        self.assertEqual(type_to_socket["DA_ModuleType_WeaponHeavy.0"], "heavy_socket")
+
+    def test_multi_pass_chain(self):
+        socket_to_types = {
+            "socket_a": {"type_x", "type_y", "type_z"},
+            "socket_b": {"type_y"},
+            "socket_c": {"type_z"},
+        }
+
+        socket_to_type, type_to_socket = resolve_exclusive_module_socket_assignments(
+            socket_to_types
+        )
+
+        self.assertEqual(socket_to_type["socket_b"], "type_y")
+        self.assertEqual(socket_to_type["socket_c"], "type_z")
+        self.assertEqual(socket_to_type["socket_a"], "type_x")
+        self.assertEqual(type_to_socket["type_x"], "socket_a")
+        self.assertEqual(type_to_socket["type_y"], "socket_b")
+        self.assertEqual(type_to_socket["type_z"], "socket_c")
+
+    def test_symmetric_ambiguity_raises(self):
+        socket_to_types = {
+            "socket_a": {"type_x", "type_y"},
+            "socket_b": {"type_x", "type_y"},
+        }
+
+        with self.assertRaises(ExclusiveAssignmentError):
+            resolve_exclusive_module_socket_assignments(socket_to_types)
+
+    def test_empty_compatible_list_raises(self):
+        socket_to_types = {
+            "empty_socket": set(),
+        }
+
+        with self.assertRaises(ExclusiveAssignmentError):
+            resolve_exclusive_module_socket_assignments(socket_to_types)
+
+    def test_double_claim_same_type_raises(self):
+        socket_to_types = {
+            "socket_a": {"type_x"},
+            "socket_b": {"type_x"},
+        }
+
+        with self.assertRaises(ExclusiveAssignmentError):
+            resolve_exclusive_module_socket_assignments(socket_to_types)
+
+    def test_exhausted_pool_raises(self):
+        socket_to_types = {
+            "socket_a": {"type_x"},
+            "socket_b": {"type_x", "type_y"},
+            "socket_c": {"type_y"},
+        }
+
+        with self.assertRaises(ExclusiveAssignmentError):
+            resolve_exclusive_module_socket_assignments(socket_to_types)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parse/test_exclusive_module_socket_matching.py
+++ b/tests/test_parse/test_exclusive_module_socket_matching.py
@@ -75,19 +75,33 @@ class TestExclusiveModuleSocketMatching(unittest.TestCase):
         with self.assertRaises(ExclusiveAssignmentError):
             resolve_exclusive_module_socket_assignments(socket_to_types)
 
-    def test_double_claim_same_type_raises(self):
+    def test_shared_single_compatible_type(self):
         socket_to_types = {
-            "socket_a": {"type_x"},
-            "socket_b": {"type_x"},
+            "DA_ModuleSocketType_ShoulderL.0": {"DA_ModuleType_Shoulder.0"},
+            "DA_ModuleSocketType_ShoulderR.0": {"DA_ModuleType_Shoulder.0"},
         }
 
-        with self.assertRaises(ExclusiveAssignmentError):
-            resolve_exclusive_module_socket_assignments(socket_to_types)
+        socket_to_type, type_to_socket = resolve_exclusive_module_socket_assignments(
+            socket_to_types
+        )
+
+        self.assertEqual(
+            socket_to_type["DA_ModuleSocketType_ShoulderL.0"],
+            "DA_ModuleType_Shoulder.0",
+        )
+        self.assertEqual(
+            socket_to_type["DA_ModuleSocketType_ShoulderR.0"],
+            "DA_ModuleType_Shoulder.0",
+        )
+        self.assertEqual(
+            type_to_socket["DA_ModuleType_Shoulder.0"],
+            "DA_ModuleSocketType_ShoulderL.0",
+        )
 
     def test_exhausted_pool_raises(self):
         socket_to_types = {
-            "socket_a": {"type_x"},
-            "socket_b": {"type_x", "type_y"},
+            "socket_a": {"type_x", "type_y"},
+            "socket_b": {"type_x"},
             "socket_c": {"type_y"},
         }
 


### PR DESCRIPTION
## Summary
- Adds a multi-pass resolver that derives the most exclusive ModuleSocketType ↔ ModuleType pairing from socket compatible-type data.
- Enriches parsed output with `exclusive_module_type_ref` on sockets and `exclusive_module_socket_type_ref` on types.
- Allows multiple single-option sockets (e.g. shoulder L/R) to share one module type; reverse mapping uses the first socket in data order.

## Test plan
- [x] `python -m unittest tests.test_parse.test_exclusive_module_socket_matching -v`
- [x] Run full parse and confirm new fields in `Objects/ModuleSocketType.json` and `Objects/ModuleType.json`