### PR TITLE
Mobility (Acceleration) stat added; chassis Armor renamed to PelvisArmor

### DIFF
--- a/src/parse/analysis.py
+++ b/src/parse/analysis.py
@@ -373,7 +373,7 @@ class Analysis:
                 distinct_stat_keys.add(stat)
 
         superficial_keys = {
-            'Health', 'Level', 'Def', 'Atk', 'Mob', 'AbilityPower', 'Mobility',
+            'Health', 'Level', 'Def', 'Atk', 'Mob', 'AbilityPower',
             'ModuleClass_1', 'ModuleClass_2', 'ModuleTag_1', 'ModuleTag_2',
             'ModuleFaction', 'FirePower', 'bIsPerk',
             'ArmorDPS', 'ShieldDPS' #for now. these are UI numbers and are often wrong. will do real dps calcs later.
@@ -416,6 +416,10 @@ class Analysis:
             # if stat_key is not in map.keys(); search by ModuleStat.short_key
             # if stat_key is in map, use it as:
             # {stat_key: module_stat_ref: str or <more_is_better>: bool}
+            # Developer: if you get an error for a stat key, check if the key could possibly relate to a ModuleStat, 
+            # if so, add the ModuleStat.id here as the value.
+            # If not, just use True/False to say if more of the stat is better or not. 
+            # E.g. TimeToReload eventually maps to False, you want less of it.
             stat_to_more_is_better = {
                 "ChargeDuration": "DA_ModuleStat_ChargeDrain.0",
                 "Cooldown": "DA_ModuleStat_Cooldown.0",
@@ -431,6 +435,7 @@ class Analysis:
                 "Armor": "DA_ModuleStat_Armor.0",
                 "TimeBetweenShots": True,
                 "DamageNoArmor": "DA_ModuleStat_ShieldDamage.0",
+                "Mobility": "DA_ModuleStat_Acceleration.0"
             }
             stat_to_more_is_better_final = {}
             for stat_key in stat_keys_to_rank:

--- a/src/parse/parsers/module.py
+++ b/src/parse/parsers/module.py
@@ -248,7 +248,7 @@ class Module(ParseObject):
                            "LoadCapacity", "EnergyCapacity"
                            ]: #already parsed above
                     pass
-                elif key in ['Health', 'Def', 'Atk', 'Mob', 'AbilityPower', 'Mobility', 'FirePower']: #flavor stats that are technically meaningless. Also not displayed anywhere as of 8-26 hangar UI changes.
+                elif key in ['Health', 'Def', 'Atk', 'Mob', 'AbilityPower', 'FirePower']: #flavor stats that are technically meaningless. Also not displayed anywhere as of 8-26 hangar UI changes.
                     pass
                 elif key in ['bIsPerk']: #no clue what this means; its bool but can vary per level, i.e. typhon chassis lvl5 true, lvl6 false
                     pass

--- a/src/parse/parsers/module.py
+++ b/src/parse/parsers/module.py
@@ -254,6 +254,8 @@ class Module(ParseObject):
                     pass
                 elif key in ["ModuleClass_1", "ModuleClass_2", "ModuleTag_1", "ModuleTag_2", "ModuleFaction"]: # these per-level ones aren't used anymore it seems. Theyre instead specified top-level though so we can still use them elsewhere.
                     pass
+                elif key == "Armor" and "LegsArmor" in level: # If LegsArmor is present, rename Armor to PelvisArmor (chassis modules have 3 separate armor pools)
+                    parsed_level["PelvisArmor"] = level["Armor"]
                 else:
                     parsed_level[key] = value
                     


### PR DESCRIPTION
* Mobility is both a ui stat and the listed acceleration, add it back in and direct it to accel stat
* Armor key for chassis renamed to PelvisArmor next to the LegsArmor to differentiate with Armor of the sole module by eg. torso