### PR TITLE
feat: Extract shoulder stats calculation to enrichment phase

### DIFF
--- a/src/parse/analysis.py
+++ b/src/parse/analysis.py
@@ -498,7 +498,10 @@ class Analysis:
                 "Armor": "DA_ModuleStat_Armor.0",
                 "TimeBetweenShots": True,
                 "DamageNoArmor": "DA_ModuleStat_ShieldDamage.0",
-                "Mobility": "DA_ModuleStat_Acceleration.0"
+                "Mobility": "DA_ModuleStat_Acceleration.0",
+                "RechargeDelay": False,
+                "RechargeTime": False,
+                "DelayAndRechargeTotal": False
             }
             stat_to_more_is_better_final = {}
             for stat_key in stat_keys_to_rank:
@@ -1006,12 +1009,6 @@ class Analysis:
                     return variables[lvl_index][stat_name]
                 return constants.get(stat_name, 0.0)
                 
-            def compute_extra_stats(shield_capacity, shield_regen, cooldown_reduction):
-                recharge_delay = 10.0 * (1.0 - cooldown_reduction)
-                recharge_time = (shield_capacity / shield_regen) if shield_regen > 0 else 0.0
-                delay_and_recharge_total = recharge_delay + recharge_time
-                return recharge_delay, recharge_time, delay_and_recharge_total
-                
             shoulder_data = {
                 'shoulder_module_ref': module.to_ref(),
                 'levels': {}
@@ -1024,7 +1021,9 @@ class Analysis:
                 regen_per_second = get_stat(lvl_index, 'ShieldRegeneration')
                 cooldown_red = get_stat(lvl_index, 'ShieldDelayReduction')
                 
-                rech_delay, rech_time, total = compute_extra_stats(shield, regen_per_second, cooldown_red)
+                rech_delay = get_stat(lvl_index, 'RechargeDelay')
+                rech_time = get_stat(lvl_index, 'RechargeTime')
+                total = get_stat(lvl_index, 'DelayAndRechargeTotal')
                 
                 shoulder_data['levels'][str(lvl)] = {
                     'Armor': armor,

--- a/src/parse/enrichment.py
+++ b/src/parse/enrichment.py
@@ -64,6 +64,9 @@ def is_virtual_bot_module(module):
 def enrich():
     logger.info("Starting enrichment phase...")
     
+    # 0. Shoulder Stats
+    enrich_shoulder_stats()
+
     # 1. Module Groups
     ModuleGroup.generate_all()
     for module in Module.objects.values():
@@ -388,3 +391,32 @@ def enrich_rarity_upgrade_costs():
             }
             
         RarityUpgradeCost(id=rarity_ref, rarity_ref=rarity_ref, costs=costs)
+
+def enrich_shoulder_stats():
+    logger.info("Enriching shoulder stats...")
+    for module in Module.objects.values():
+        if 'Shoulder' not in module.id:
+            continue
+            
+        scalars = getattr(module, 'module_scalars', {})
+        levels = scalars.get('levels', {})
+        variables = levels.get('variables', [])
+        constants = levels.get('constants', {})
+        
+        for lvl_index in range(len(variables)):
+            def get_stat(stat_name):
+                if stat_name in variables[lvl_index]:
+                    return variables[lvl_index][stat_name]
+                return constants.get(stat_name, 0.0)
+                
+            shield = get_stat('ShieldAmount')
+            regen_per_second = get_stat('ShieldRegeneration')
+            cooldown_red = get_stat('ShieldDelayReduction')
+            
+            recharge_delay = 10.0 * (1.0 - cooldown_red)
+            recharge_time = (shield / regen_per_second) if regen_per_second > 0 else 0.0
+            delay_and_recharge_total = recharge_delay + recharge_time
+            
+            variables[lvl_index]['RechargeDelay'] = recharge_delay
+            variables[lvl_index]['RechargeTime'] = recharge_time
+            variables[lvl_index]['DelayAndRechargeTotal'] = delay_and_recharge_total

--- a/src/parse/parse.py
+++ b/src/parse/parse.py
@@ -42,8 +42,8 @@ def main():
     parse_factory_presets()
     parse_powerups()
     parse_shop_cards()
-    analyze()
     enrich()
+    analyze()
 
 
     ProgressionTable.to_file()


### PR DESCRIPTION
## Description
Extracted shoulder module stats calculation (RechargeDelay, RechargeTime, and DelayAndRechargeTotal) to the enrichment phase (enrichment.py). This allows nalysis.py's level-differ logic to automatically calculate and rank level differences for these stats across shoulder modules.

## Summary of Changes
1. **enrichment.py**: Added enrich_shoulder_stats() to compute shoulder stats per level and inject them into each shoulder module's module_scalars['levels']['variables'].
2. **parse.py**: Updated sequence to run enrich() before nalyze() so analysis functions operate on fully enriched modules.
3. **nalysis.py**: 
   - Simplified nalyze_shoulder_profiles() to retrieve enriched shoulder stats via get_stat().
   - Updated get_more_is_better_map in get_ranks_per_stat() to map RechargeDelay, RechargeTime, and DelayAndRechargeTotal to False (less duration is better), enabling accurate percentile calculations.
4. **Generated Outputs**: Updated level_diffs_by_module.json to include diffs and percentiles for these shoulder stats.