### PR TITLE
feat: Add Stat ParseObject with synthetic ModuleStat support

### DIFF
--- a/src/parse/analysis.py
+++ b/src/parse/analysis.py
@@ -475,57 +475,9 @@ class Analysis:
         stat_keys_to_not_rank = {'PrimaryParameter', 'SecondaryParameter'}
         stat_keys_to_rank = [key for key in distinct_stat_keys if key not in stat_keys_to_not_rank]
 
-        def get_more_is_better_map(stat_keys_to_rank):
-            # if stat_key is not in map.keys(); search by ModuleStat.short_key
-            # if stat_key is in map, use it as:
-            # {stat_key: module_stat_ref: str or <more_is_better>: bool}
-            # Developer: if you get an error for a stat key, check if the key could possibly relate to a ModuleStat, 
-            # if so, add the ModuleStat.id here as the value.
-            # If not, just use True/False to say if more of the stat is better or not. 
-            # E.g. TimeToReload eventually maps to False, you want less of it.
-            stat_to_more_is_better = {
-                "ChargeDuration": "DA_ModuleStat_ChargeDrain.0",
-                "Cooldown": "DA_ModuleStat_Cooldown.0",
-                "ShieldRegeneration": "DA_ModuleStat_ShieldRegeneration.0",
-                "TimeToReload": "DA_ModuleStat_ReloadingTime.0",
-                "DamageArmor": "DA_ModuleStat_ArmorDamage.0",
-                "AoeArmor": True,
-                "RoundsPerMinute": "DA_ModuleStat_FireRate.0",
-                "FuelCapacity": "DA_ModuleStat_FuelCapacity.0",
-                "ShieldAmount": "DA_ModuleStat_ShieldAmount.0",
-                "ShieldDelayReduction": "DA_ModuleStat_ShieldDelayReduction.0",
-                "AoeNoArmor": True,
-                "Armor": "DA_ModuleStat_Armor.0",
-                "TimeBetweenShots": True,
-                "DamageNoArmor": "DA_ModuleStat_ShieldDamage.0",
-                "Mobility": "DA_ModuleStat_Acceleration.0",
-                "RechargeDelay": False,
-                "RechargeTime": False,
-                "DelayAndRechargeTotal": False
-            }
-            stat_to_more_is_better_final = {}
-            for stat_key in stat_keys_to_rank:
-                entry = stat_to_more_is_better.get(stat_key)
-                if entry is None:
-                    module_stat = next((stat for stat in ModuleStat.objects.values() if stat.short_key == stat_key), None)
-                    if module_stat is None:
-                        if stat_key.startswith('DPS_'): #dps stats are all more is better
-                            more_is_better = True
-                        else:
-                            raise ValueError(f"stat_key: {stat_key}, Unknown module stat with this short_key")
-                    more_is_better = getattr(module_stat, 'more_is_better', True)
-                elif isinstance(entry, str):
-                    module_stat = ModuleStat.objects[entry]
-                    more_is_better = getattr(module_stat, 'more_is_better', True)
-                elif isinstance(entry, bool):
-                    more_is_better = entry
-                else:
-                    raise ValueError(f"Unknown more_is_better entry for stat {stat_key}: {entry}")
-                stat_to_more_is_better_final[stat_key] = more_is_better
-            return stat_to_more_is_better_final
-        stat_to_more_is_better = get_more_is_better_map(stat_keys_to_rank)
+        from parsers.stat import Stat
 
-        def rank_stats(level_diffs_by_module, stat_keys_to_rank, stat_to_more_is_better):
+        def rank_stats(level_diffs_by_module, stat_keys_to_rank):
             stat_ranks = {key: {} for key in stat_keys_to_rank}
             for stat_key in stat_ranks:
                 module_increases = []
@@ -533,12 +485,21 @@ class Analysis:
                     percent_increase = module_diff_data['stats_percent_increase'].get(stat_key)
                     if percent_increase is not None:
                         module_increases.append((module_id, percent_increase))
-                should_reverse = not stat_to_more_is_better.get(stat_key, None)
+                
+                stat_obj = Stat.objects.get(stat_key)
+                if stat_obj is not None:
+                    module_stat = ModuleStat.get_from_ref(stat_obj.module_stat_ref)
+                    more_is_better = getattr(module_stat, 'more_is_better', True)
+                else:
+                    logger.warning(f"Stat {stat_key} not found in Stat.objects. Defaulting to more_is_better = True")
+                    more_is_better = True
+
+                should_reverse = not more_is_better
                 module_increases.sort(key=lambda x: (float('-inf') if isinstance(x[1], str) else x[1]), reverse=should_reverse)
                 for rank, (module_id, _) in enumerate(module_increases[::-1]):
                     stat_ranks[stat_key][module_id] = rank
             return stat_ranks
-        return rank_stats(level_diffs_by_module, stat_keys_to_rank, stat_to_more_is_better)
+        return rank_stats(level_diffs_by_module, stat_keys_to_rank)
 
     @staticmethod
     def get_ranks_per_module(stat_ranks, module_ids: list):

--- a/src/parse/enrichment.py
+++ b/src/parse/enrichment.py
@@ -23,6 +23,7 @@ from exclusive_module_socket_matching import (
     resolve_exclusive_module_socket_assignments,
 )
 from parsers.rarity_upgrade_cost import RarityUpgradeCost
+from parsers.stat import Stat
 
 PILOT_TYPE_LEGENDARY_REF = 'OBJID_PilotType::DA_PilotType_Legendary.0'
 
@@ -67,6 +68,8 @@ def enrich():
     # 0. Shoulder Stats
     enrich_shoulder_stats()
 
+    # 0.5 Stats
+    Stat.generate_all()
     # 1. Module Groups
     ModuleGroup.generate_all()
     for module in Module.objects.values():

--- a/src/parse/parse.py
+++ b/src/parse/parse.py
@@ -28,6 +28,7 @@ from parsers.virtual_bot import VirtualBot
 from parsers.module_group import ModuleGroup
 from parsers.shop_card import ShopCard, parse_shop_cards
 from parsers.rarity_upgrade_cost import RarityUpgradeCost
+from parsers.stat import Stat
 def main():
     """Main parsing function - uses global OPTIONS singleton."""
     os.makedirs(OPTIONS.output_dir, exist_ok=True)
@@ -72,6 +73,7 @@ def main():
     ModuleCategory.to_file()
     ModuleSocketType.to_file()
     ModuleStat.to_file()
+    Stat.to_file()
     ModuleStatsTable.to_file()
     UpgradeCost.to_file()
     ScrapReward.to_file()

--- a/src/parse/parsers/stat.py
+++ b/src/parse/parsers/stat.py
@@ -1,0 +1,104 @@
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from parsers.object import ParseObject
+from parsers.module_stat import ModuleStat
+from parsers.stat_maps import STAT_KEY_TO_MODULE_STAT_ID, SYNTHETIC_STAT_MORE_IS_BETTER
+from loguru import logger
+
+class Stat(ParseObject):
+    objects = dict()  # Dict to hold all Stat instances keyed by short_key ID
+
+    def _parse(self):
+        # Stat instances are constructed programmatically during enrichment
+        pass
+
+    @classmethod
+    def generate_all(cls):
+        """
+        Enrichment generator that creates Stat objects and synthetic ModuleStats for all distinct_stat_keys.
+        """
+        distinct_stat_keys = set()
+        superficial_keys = {
+            'Health', 'Level', 'Def', 'Atk', 'Mob', 'AbilityPower',
+            'ModuleClass_1', 'ModuleClass_2', 'ModuleTag_1', 'ModuleTag_2',
+            'ModuleFaction', 'FirePower', 'bIsPerk',
+            'ArmorDPS', 'ShieldDPS', 'scrap_rewards_refs', 'upgrade_cost_ref',
+            'PrimaryParameter', 'SecondaryParameter'
+        }
+
+        from parsers.module import Module
+        for module in Module.objects.values():
+            if getattr(module, 'production_status', None) != 'Ready':
+                continue
+            
+            level_data_attrs = ['module_scalars', 'abilities_scalars']
+            for attr in level_data_attrs:
+                attr_data = getattr(module, attr, None)
+                if attr_data is None:
+                    continue
+                
+                # Handle lists of scalars (abilities_scalars) or a single dict (module_scalars)
+                items = attr_data if isinstance(attr_data, list) else [attr_data]
+                for item in items:
+                    if not isinstance(item, dict) or 'levels' not in item:
+                        continue
+                    levels_info = item['levels']
+                    if 'variables' in levels_info and levels_info['variables']:
+                        for key in levels_info['variables'][0].keys():
+                            if key not in superficial_keys:
+                                distinct_stat_keys.add(key)
+        
+        for stat_key in distinct_stat_keys:
+            if stat_key in cls.objects:
+                continue
+
+            target_module_stat = None
+
+            # Path A: Explicit manual mapping to an existing ModuleStat ID
+            mapped_stat_id = STAT_KEY_TO_MODULE_STAT_ID.get(stat_key)
+            if mapped_stat_id is not None:
+                target_module_stat = ModuleStat.get_from_id(mapped_stat_id)
+                if target_module_stat is None:
+                    raise ValueError(
+                        f"Stat key '{stat_key}' maps to ModuleStat ID '{mapped_stat_id}' in STAT_KEY_TO_MODULE_STAT_ID, "
+                        f"but no ModuleStat with ID '{mapped_stat_id}' exists."
+                    )
+
+            # Path B: 1-to-1 short_key match against existing ModuleStats
+            if target_module_stat is None:
+                target_module_stat = next(
+                    (ms for ms in ModuleStat.objects.values() if getattr(ms, 'short_key', None) == stat_key),
+                    None
+                )
+
+            # Path C: Dynamic DPS prefix check (or synthetic lookup)
+            if target_module_stat is None and stat_key.startswith('DPS_'):
+                synthetic_id = f"DA_ModuleStat_Synthetic_{stat_key}"
+                target_module_stat = ModuleStat.get_from_id(synthetic_id)
+                if target_module_stat is None:
+                    target_module_stat = ModuleStat(synthetic_id, source_data={"Properties": {}})
+                    target_module_stat.short_key = stat_key
+                    target_module_stat.more_is_better = True
+
+            # Path D: Synthetic ModuleStat creation via SYNTHETIC_STAT_MORE_IS_BETTER
+            if target_module_stat is None:
+                if stat_key in SYNTHETIC_STAT_MORE_IS_BETTER:
+                    synthetic_id = f"DA_ModuleStat_Synthetic_{stat_key}"
+                    more_is_better_val = SYNTHETIC_STAT_MORE_IS_BETTER[stat_key]
+                    target_module_stat = ModuleStat(synthetic_id, source_data={"Properties": {}})
+                    target_module_stat.short_key = stat_key
+                    target_module_stat.more_is_better = more_is_better_val
+                else:
+                    # Developer Notification Error
+                    raise ValueError(
+                        f"Newly added stat short_key '{stat_key}' does not have a 1-to-1 ModuleStat match.\n"
+                        f"- If '{stat_key}' relates to an existing ModuleStat, map its ID in STAT_KEY_TO_MODULE_STAT_ID in 'stat_maps.py'.\n"
+                        f"- If '{stat_key}' does NOT relate to an existing ModuleStat, define its 'more_is_better' (True/False) entry in SYNTHETIC_STAT_MORE_IS_BETTER in 'stat_maps.py'."
+                    )
+
+            # Create the Stat ParseObject
+            stat_obj = cls(id=stat_key, source_data={})
+            stat_obj.module_stat_ref = target_module_stat.to_ref()

--- a/src/parse/parsers/stat_maps.py
+++ b/src/parse/parsers/stat_maps.py
@@ -1,0 +1,30 @@
+# 1. Map: Module-level short_key -> ModuleStat ID
+# Used when the stat key used in Module levels does not match ModuleStat.short_key 1-to-1.
+# Developer guidance: If a newly added stat short_key relates to an existing ModuleStat, add the mapping here.
+STAT_KEY_TO_MODULE_STAT_ID: dict[str, str] = {
+    "ChargeDuration":       "DA_ModuleStat_ChargeDrain.0",
+    "Cooldown":             "DA_ModuleStat_Cooldown.0",
+    "ShieldRegeneration":   "DA_ModuleStat_ShieldRegeneration.0",
+    "TimeToReload":         "DA_ModuleStat_ReloadingTime.0",
+    "DamageArmor":          "DA_ModuleStat_ArmorDamage.0",
+    "RoundsPerMinute":      "DA_ModuleStat_FireRate.0",
+    "FuelCapacity":         "DA_ModuleStat_FuelCapacity.0",
+    "ShieldAmount":         "DA_ModuleStat_ShieldAmount.0",
+    "ShieldDelayReduction": "DA_ModuleStat_ShieldDelayReduction.0",
+    "Armor":                "DA_ModuleStat_Armor.0",
+    "DamageNoArmor":        "DA_ModuleStat_ShieldDamage.0",
+    "Mobility":             "DA_ModuleStat_Acceleration.0",
+}
+
+# 2. Map: Module-level short_key -> more_is_better (bool)
+# Used ONLY for stats that do not have a ModuleStat in game data (neither 1-to-1 nor in STAT_KEY_TO_MODULE_STAT_ID).
+# Synthetic ModuleStats will be created for these with ID "DA_ModuleStat_Synthetic_<short_key>".
+# Developer guidance: If a newly added stat short_key cannot be related to an existing ModuleStat, add its more_is_better setting here.
+SYNTHETIC_STAT_MORE_IS_BETTER: dict[str, bool] = {
+    "AoeArmor":              True,
+    "AoeNoArmor":            True,
+    "TimeBetweenShots":      True,
+    "RechargeDelay":         False,
+    "RechargeTime":          False,
+    "DelayAndRechargeTotal": False,
+}


### PR DESCRIPTION
## Description
Creates a new Stat ParseObject that replaces the hardcoded stat_to_more_is_better map in nalysis.py with a structured, extensible data model.

## Summary of Changes
1. **stat_maps.py** (NEW): Defines two developer-maintained mappings:
   - STAT_KEY_TO_MODULE_STAT_ID: explicit short_key → ModuleStat ID overrides
   - SYNTHETIC_STAT_MORE_IS_BETTER: more_is_better value for stats with no game-data ModuleStat
2. **stat.py** (NEW): The Stat ParseObject. generate_all() discovers distinct stat keys from all Ready modules and resolves each to a ModuleStat via a 4-path lookup:
   - Path A: Explicit map (STAT_KEY_TO_MODULE_STAT_ID)
   - Path B: 1-to-1 short_key match against existing ModuleStat objects
   - Path C: DPS_ prefix → synthetic ModuleStat (more_is_better=True)
   - Path D: Synthetic fallback via SYNTHETIC_STAT_MORE_IS_BETTER; raises a developer-friendly error for unknown new keys
   Synthetic ModuleStats use the ID format DA_ModuleStat_Synthetic_<short_key>.
3. **enrichment.py**: Calls Stat.generate_all() during the enrichment phase.
4. **parse.py**: Calls Stat.to_file() to persist Stat objects.
5. **nalysis.py**: get_ranks_per_stat() now resolves more_is_better through Stat.objects instead of a local hardcoded dict.